### PR TITLE
metanorma/mn-templates-ietf#3 Fix rfc2629.dtd (No such file or directory) error by using absolute path to rfc2629.dtd

### DIFF
--- a/lib/asciidoctor/rfc/common/base.rb
+++ b/lib/asciidoctor/rfc/common/base.rb
@@ -265,7 +265,9 @@ module Asciidoctor
           doc.root.add_previous_sibling(pi)
         end
 
-        doc.create_internal_subset("rfc", nil, "rfc2629.dtd")
+        dtd = File.join(File.expand_path('../../../..', File.dirname(__FILE__)), "rfc2629.dtd")
+
+        doc.create_internal_subset("rfc", nil, dtd)
         rfc_pis = common_rfc_pis(node)
         rfc_pis.each_pair do |k, v|
           pi = Nokogiri::XML::ProcessingInstruction.new(doc,

--- a/spec/asciidoctor/rfc/v2/appendix_spec.rb
+++ b/spec/asciidoctor/rfc/v2/appendix_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders appendix when section tagged with appendix" do
     VCR.use_cassette "rfc2_appendix" do
-      expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+      expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
         = Document title
         :docName:
         Author
@@ -14,8 +14,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
         == Appendix
         text
      INPUT
-        <?xml version="1.0" encoding="US-ASCII"?>
-        <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+        #{XML_HDR}
 
         <rfc
         submissionType="IETF">
@@ -39,7 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
   it "renders appendix when section follows references" do
     VCR.use_cassette "rfc2_appendix" do
-      expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+      expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
         = Document title
         :docName:
         Author
@@ -78,8 +77,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
         == Appendix
         text
       INPUT
-        <?xml version="1.0" encoding="US-ASCII"?>
-        <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+        #{XML_HDR}
 
         <rfc
         submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/area_spec.rb
+++ b/spec/asciidoctor/rfc/v2/area_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders areas" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -30,7 +29,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "deals with entities in areas" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -39,8 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/author_spec.rb
+++ b/spec/asciidoctor/rfc/v2/author_spec.rb
@@ -1,24 +1,16 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders all options with short author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       John Doe Horton <john.doe@email.com>
 
       == Section 1
       text
- INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+  INPUT
+      #{XML_HDR}
 
-       <?rfc strict="yes"?>
-       <?rfc toc="yes"?>
-       <?rfc tocdepth="4"?>
-       <?rfc symrefs="yes"?>
-       <?rfc sortrefs="yes"?>
-       <?rfc compact="yes"?>
-       <?rfc subcompact="no"?>
       <rfc
                 submissionType="IETF">
       <front>
@@ -42,7 +34,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders all options with multiple short author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       John Doe Horton <john.doe@email.com>; Joanna Diva Munez <joanna.munez@email.com>
@@ -50,8 +42,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -84,7 +75,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders all options with long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -106,8 +97,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -140,7 +130,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "deals with entities for all options under long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :fullname: John <Doe> Horton
       :lastname: Horton & Horton
@@ -160,8 +150,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -194,7 +183,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders all options with multiple long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -230,8 +219,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -280,7 +268,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "respects multiple lines in street" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -292,7 +280,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       :email: john.doe@email.com
       :uri: http://example.com
       :phone: 555 5655
-      :street: 57 Mt Pleasant St\ Technology Park
+      :street: 57 Mt Pleasant St\\ Technology Park
       :city: Dullsville
       :region: NSW
       :country: Australia
@@ -301,8 +289,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -336,7 +323,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "ignores initials attribute from Asciidoc" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -357,8 +344,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -391,7 +377,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "permits corporate authors" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :role: editor
@@ -409,8 +395,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/comments_spec.rb
+++ b/spec/asciidoctor/rfc/v2/comments_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "ignores actual Asciidoctor comments" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -16,8 +16,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
         Multiblock ignorable comment
       ////
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                 submissionType="IETF">
@@ -35,7 +34,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "uses Asciidoc inline NOTE admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -46,8 +45,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       NOTE: This is a note
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>
@@ -71,7 +69,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "uses any Asciidoc inline admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -82,8 +80,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       WARNING: This is a note
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>
@@ -107,7 +104,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "strips any inline formatting within Asciidoc inline admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -146,16 +143,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <?xml-stylesheet type="text/xsl" href="rfc2629.xslt"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
+      #{XML_HDR}
       <rfc submissionType="IETF">
       <front>
 
@@ -203,7 +191,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "uses Asciidoc block admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -226,8 +214,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ....
       ====
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>
@@ -263,7 +250,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "uses all options of the Asciidoc block admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -279,8 +266,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       Any admonition inside the body of the text is a comment.
       ====
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>
@@ -304,7 +290,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "has a comment at the start of a section" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
 
@@ -313,8 +299,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>

--- a/spec/asciidoctor/rfc/v2/crossref_spec.rb
+++ b/spec/asciidoctor/rfc/v2/crossref_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders links" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -11,8 +11,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       http://example.com/
       http://example.com/[linktext]
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -31,7 +30,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders cross-references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -52,8 +51,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 5
       See <<crossreference,format=title>>
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -82,7 +80,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders cross-references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -103,8 +101,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 5
       See <<crossreference,format=title>>
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -133,7 +130,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "does not support fragments in cross-references to bibliography" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -161,8 +158,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -197,7 +193,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders cross-references with dots to bibliography" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -225,8 +221,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -261,7 +256,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders relref references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -301,8 +296,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       </reference>
       ++++
     INPUT
-       <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+       #{XML_HDR}
 
        <rfc submissionType="IETF">
        <front>

--- a/spec/asciidoctor/rfc/v2/date_spec.rb
+++ b/spec/asciidoctor/rfc/v2/date_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "date"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders the date" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -11,8 +11,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -30,7 +29,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders the revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -39,8 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -58,7 +56,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "gives precedence to revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -68,8 +66,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -87,7 +84,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "permits year-only revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -96,8 +93,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -115,7 +111,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "permits year-month revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -124,8 +120,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -144,13 +139,12 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
   it "supplies today's date if no date given" do
     # today's date is frozen at 2000-01-01 by spec_helper
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
       <rfc submissionType="IETF">
          <front>
          <title>Document title</title>
@@ -164,14 +158,13 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
   it "supplies today's date if invalid date given" do
     # today's date is frozen at 2000-01-01 by spec_helper
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :date: fred
       Author
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
       <rfc submissionType="IETF">
         <front>
           <title>Document title</title>

--- a/spec/asciidoctor/rfc/v2/dlist_spec.rb
+++ b/spec/asciidoctor/rfc/v2/dlist_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders an inline definition list" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :inline-definition-list: true
@@ -34,15 +34,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       A:: B
       C:: D
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
+      #{XML_HDR}
       <rfc submissionType="IETF">
       <front>
          <title>Document title</title>

--- a/spec/asciidoctor/rfc/v2/document_spec.rb
+++ b/spec/asciidoctor/rfc/v2/document_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "byebug"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders the minimal document w/ default values" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -31,7 +30,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders all document attributes for RFC" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :name: 1111
@@ -52,8 +51,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc ipr="full3978" obsoletes="1, 2" updates="10, 11" category="info" consensus="no" submissionType="IRTF" iprExtract="ipr_extract_value" number="1111" seriesNo="12" xml:lang="en">
       <front>
@@ -77,7 +75,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders all document attributes for Internet Draft" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :name: draft-03-draft
@@ -97,8 +95,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc ipr="full3978" obsoletes="1, 2" updates="10, 11" category="info" consensus="no" submissionType="IRTF" iprExtract="ipr_extract_value" docName="draft-03-draft" seriesNo="12" xml:lang="en">
       <front>
@@ -122,7 +119,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders back matter" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -134,8 +131,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Appendix
       Lipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF">
       <front>

--- a/spec/asciidoctor/rfc/v2/front_spec.rb
+++ b/spec/asciidoctor/rfc/v2/front_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders author, date, area, workgroup, keyword in sequence" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :abbrev: abbrev_value
@@ -14,8 +14,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF" docName="rfc-1111">
@@ -37,7 +36,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
     OUTPUT
   end
   it "deals with entities in titles" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document on the derivation of x & y < z
       Author
       :abbrev: deriv x & y < z
@@ -50,8 +49,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF" docName="rfc-1111">

--- a/spec/asciidoctor/rfc/v2/indexterm_spec.rb
+++ b/spec/asciidoctor/rfc/v2/indexterm_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders index" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -12,8 +12,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       is visible in the text,
       this one is not (((indexterm, index-subterm))).
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -33,7 +32,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "does not render tertiary index terms" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -44,8 +43,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       is visible in the text,
       this one with a tertiary term is not (((indexterm, index-subterm, index-subsubterm))).
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/inline_formatting_spec.rb
+++ b/spec/asciidoctor/rfc/v2/inline_formatting_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "treats bcp14 macro in v2 as <strong>" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       This [bcp14]#must not# stand
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -29,7 +28,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "respects Asciidoctor inline formatting" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -38,8 +37,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       _Text_ *Text* `Text` "`Text`" '`Text`' ^Superscript^ ~Subscript~
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -57,7 +55,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "allows suppression of smart quotes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -67,8 +65,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       "`Text`" '`Text`'
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -86,7 +83,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders stem as literal" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -96,8 +93,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       stem:[sqrt(4) = 2]
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -114,7 +110,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
     OUTPUT
   end
   it "deals with non-Ascii characters" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -124,8 +120,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       Hello René! Hello Владимир!
 
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -142,7 +137,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
     OUTPUT
   end
   it "deals with HTML entities" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -154,8 +149,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 2
       Hello &lt;&nbsp;(&amp;lt;)
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -187,7 +181,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
     OUTPUT
   end
   it "removes markup within spanx" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -196,8 +190,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       `This is http://www.example.com _a_ *citation*`
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/keyword_spec.rb
+++ b/spec/asciidoctor/rfc/v2/keyword_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders keywords" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -31,7 +30,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
      OUTPUT
   end
   it "deals with entities in keywords" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -40,8 +39,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/paragraph_spec.rb
+++ b/spec/asciidoctor/rfc/v2/paragraph_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "suppresses smart apostrophes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :smart-quotes: false
@@ -28,15 +28,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Dante's Revenge
       Don't panic!
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
+      #{XML_HDR}
       <rfc submissionType="IETF">
       <front>
         <title abbrev="abbrev_value">Document title</title>

--- a/spec/asciidoctor/rfc/v2/preamble_spec.rb
+++ b/spec/asciidoctor/rfc/v2/preamble_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders no abstract if preamble has no content" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -9,8 +9,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -28,7 +27,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders preamble contents as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -40,8 +39,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -63,7 +61,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders verse in preamble as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -74,8 +72,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -96,7 +93,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders admonitions in preamble as notes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -110,8 +107,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -132,7 +128,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders admonitions in preamble as notes, following an abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -148,8 +144,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -171,7 +166,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "supplies default titles for notes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -186,8 +181,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v2/references_spec.rb
+++ b/spec/asciidoctor/rfc/v2/references_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders external RFC XML references as entities" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -151,7 +151,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ++++
     INPUT
       <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+      <!DOCTYPE rfc SYSTEM "#{dtd_absolute_path}" [
       <!ENTITY RFC2119 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
       <!ENTITY I-D.abarth-cake SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3//reference.I-D.draft-abarth-cake-00.xml">
       ]>
@@ -185,7 +185,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders skeletal external RFC XML references as entities" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -218,7 +218,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ++++
     INPUT
       <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+      <!DOCTYPE rfc SYSTEM "#{dtd_absolute_path}" [
       <!ENTITY RFC2119 SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml">
       <!ENTITY I-D.abarth-cake SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3//reference.I-D.abarth-cake.xml">
       ]>
@@ -252,7 +252,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders skeletal external RFC XML references with drafts as entities" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -274,7 +274,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ++++
     INPUT
       <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd" [
+      <!DOCTYPE rfc SYSTEM "#{dtd_absolute_path}" [
       <!ENTITY I-D.abarth-cake SYSTEM "https://xml2rfc.tools.ietf.org/public/rfc/bibxml3//reference.I-D.draft-abarth-cake-00.xml">
       ]>
       <?rfc strict="yes"?>

--- a/spec/asciidoctor/rfc/v2/section_spec.rb
+++ b/spec/asciidoctor/rfc/v2/section_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders section with attributes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -13,8 +13,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -33,7 +32,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "strips formatting in section titles" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -45,8 +44,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -66,7 +64,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
 
   it "renders HTML entities and Non-ASCII characters and in section title attributes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -78,8 +76,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -98,7 +95,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders subsections" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -116,8 +113,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ==== Subsection 1.2.1
       Para 3
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -144,7 +140,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "ignores sectnums" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -164,8 +160,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ==== Subsection 1.2.1
       Para 3
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -192,7 +187,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "ignores page breaks" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -205,8 +200,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -225,7 +219,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "ignores horizontal rules" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -238,8 +232,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -258,7 +251,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "renders floating titles" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -271,8 +264,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 2
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -292,7 +284,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "supresses natural cross-references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -313,17 +305,8 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       ...
       ++++
     INPUT
-    <?xml version="1.0" encoding="US-ASCII"?>
-<?xml-stylesheet type="text/xsl" href="rfc2629.xslt"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-<?rfc strict="yes"?>
-<?rfc compact="yes"?>
-<?rfc subcompact="no"?>
-<?rfc toc="yes"?>
-<?rfc tocdepth="4"?>
-<?rfc symrefs="yes"?>
-<?rfc sortrefs="yes"?>
-<rfc submissionType="IETF">
+    #{XML_HDR}
+      <rfc submissionType="IETF">
        <front>
          <title abbrev="abbrev_value">Document title</title>
          <author fullname="Author"/>
@@ -339,7 +322,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
        ...</reference>
        </references>
        </back>
-       </rfc>
+      </rfc>
     OUTPUT
   end
 end

--- a/spec/asciidoctor/rfc/v2/workgroup_spec.rb
+++ b/spec/asciidoctor/rfc/v2/workgroup_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V2::Converter do
   it "renders workgroups" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -30,7 +29,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
   end
 
   it "deals with entities in workgroups" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -39,8 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V2::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/appendix_spec.rb
+++ b/spec/asciidoctor/rfc/v3/appendix_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders appendix when section tagged with appendix" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -13,8 +13,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Appendix
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -38,7 +37,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders appendix when section follows references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -77,8 +76,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Appendix
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/area_spec.rb
+++ b/spec/asciidoctor/rfc/v3/area_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders areas" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>
@@ -32,7 +31,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "deals with entities in areas" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -41,8 +40,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>

--- a/spec/asciidoctor/rfc/v3/author_spec.rb
+++ b/spec/asciidoctor/rfc/v3/author_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders all options with short author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       John Doe Horton <john.doe@email.com>
@@ -9,8 +9,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>
@@ -32,7 +31,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders all options with multiple short author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       John Doe Horton <john.doe@email.com>; Joanna Diva Munez <joanna.munez@email.com>
@@ -40,8 +39,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>
@@ -68,7 +66,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders all options with long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -89,8 +87,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -124,7 +121,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "deals with entities for all options under long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :fullname: John <Doe> Horton
       :lastname: Horton & Horton
@@ -144,8 +141,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
        <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -178,7 +174,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders all options with multiple long author syntax" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -213,8 +209,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -264,7 +259,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "respects multiple lines in street" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -276,7 +271,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       :email: john.doe@email.com
       :uri: http://example.com
       :phone: 555 5655
-      :street: 57 Mt Pleasant St\ Technology Park
+      :street: 57 Mt Pleasant St\\ Technology Park
       :city: Dullsville
       :region: NSW
       :country: Australia
@@ -285,11 +280,9 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
-      <rfc prepTime="2000-01-01T05:00:00Z"
-                version="3" submissionType="IETF">
+      <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
       <title>Document title</title>
       <author fullname="John Doe Horton" initials="J. D." surname="Horton" role="editor">
@@ -321,7 +314,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "ignores initials attribute from Asciidoc" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -342,8 +335,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -377,7 +369,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "permits corporate authors" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :role: editor
@@ -395,8 +387,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -430,7 +421,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "respects postal line attributes, with multiple lines" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -442,13 +433,12 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       :email: john.doe@email.com
       :uri: http://example.com
       :phone: 555 5655
-      :postal-line: 57 Mt Pleasant St\ Dullsville\ NSW\ Australia\ 3333
+      :postal-line: 57 Mt Pleasant St\\ Dullsville\\ NSW\\ Australia\\ 3333
 
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -482,7 +472,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "gives postal lines priority over address lines" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       :fullname: John Doe Horton
@@ -494,7 +484,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       :email: john.doe@email.com
       :uri: http://example.com
       :phone: 555 5655
-      :postal-line: 57 Mt Pleasant St\ Dullsville\ NSW\ Australia\ 3333
+      :postal-line: 57 Mt Pleasant St\\ Dullsville\\ NSW\\ Australia\\ 3333
       :street: 57 Mt Pleasant St
       :city: Dullsville
       :region: NSW
@@ -504,8 +494,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/comments_spec.rb
+++ b/spec/asciidoctor/rfc/v3/comments_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "ignores actual Asciidoctor comments" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -15,8 +15,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
         Multiblock ignorable comment
       ////
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -36,7 +35,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "uses Asciidoc inline NOTE admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -47,8 +46,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       NOTE: This is a note
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -69,7 +67,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "uses any Asciidoc inline admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -80,8 +78,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       WARNING: This is a note
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -102,7 +99,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "uses full range of inline formatting within Asciidoc inline admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -142,8 +139,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
        <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
@@ -187,7 +183,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "uses Asciidoc block admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -206,8 +202,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       . Celery makes them sad.
       ====
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -232,7 +227,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "uses all options of the Asciidoc block admonition" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -248,8 +243,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       Any admonition inside the body of the text is a comment.
       ====
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -275,7 +269,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "has a comment at the start of a section" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
 
@@ -284,8 +278,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>

--- a/spec/asciidoctor/rfc/v3/crossref_spec.rb
+++ b/spec/asciidoctor/rfc/v3/crossref_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders links" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -11,8 +11,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       http://example.com/
       http://example.com/[linktext]
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -32,7 +31,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders cross-references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -53,8 +52,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 5
       See <<crossreference,format=title>>
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -88,7 +86,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders cross-references to bibliography" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -131,8 +129,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -185,7 +182,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders relref references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -225,8 +222,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
        <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>

--- a/spec/asciidoctor/rfc/v3/date_spec.rb
+++ b/spec/asciidoctor/rfc/v3/date_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders the date" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -30,7 +29,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders the revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -39,8 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                version="3" submissionType="IETF">
@@ -59,7 +57,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "gives precedence to revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -69,8 +67,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                version="3" submissionType="IETF">
@@ -89,7 +86,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "permits year-only revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -98,8 +95,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                version="3" submissionType="IETF">
@@ -118,7 +114,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "permits year-month revdate" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -127,8 +123,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/document_spec.rb
+++ b/spec/asciidoctor/rfc/v3/document_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "byebug"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders the minimal document w/ default values" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>
@@ -29,7 +28,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders all document attributes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -50,8 +49,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc ipr="ipr_value" obsoletes="1, 2" updates="10, 11" prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IRTF" indexInclude="true" iprExtract="ipr_extract_value" sortRefs="true" symRefs="false" tocInclude="false" tocDepth="2">
@@ -70,7 +68,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders back matter" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -82,8 +80,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Appendix
       Lipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/front_spec.rb
+++ b/spec/asciidoctor/rfc/v3/front_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders series, author, date, area, workgroup, keyword in sequence" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :abbrev: abbrev_value
@@ -14,8 +14,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/indexterm_spec.rb
+++ b/spec/asciidoctor/rfc/v3/indexterm_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders index" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -12,8 +12,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       is visible in the text,
       this one is not (((indexterm, index-subterm))).
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -34,7 +33,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "does not render tertiary index terms" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -45,8 +44,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       is visible in the text,
       this one with a tertiary term is not (((indexterm, index-subterm, index-subsubterm))).
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/inline_formatting_spec.rb
+++ b/spec/asciidoctor/rfc/v3/inline_formatting_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "treats bcp14 macro in v3 as <bcp14>" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       This [bcp14]#must not# stand
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -30,7 +29,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "treats boldfaced capital BCP14 in v3 as <bcp14> by default" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -39,8 +38,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       This *MUST NOT* stand
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -59,7 +57,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "treats boldfaced capital BCP14 in v3 as normal strong text, if flag :no-rfc-bold-bcp14:." do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :no-rfc-bold-bcp14:
@@ -69,8 +67,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       This *MUST NOT* stand
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -89,7 +86,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "respects Asciidoctor inline formatting" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -98,8 +95,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       _Text_ *Text* `Text` "`Text`" '`Text`' ^Superscript^ ~Subscript~
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -118,7 +114,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "allows suppression of smart quotes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc2, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc2, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -128,8 +124,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       "`Text`" '`Text`'
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc
                submissionType="IETF">
@@ -146,7 +141,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders stem as literal" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -156,8 +151,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       stem:[sqrt(4) = 2]
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -176,7 +170,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "render line break within table" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
 
@@ -192,8 +186,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       cell
       |===
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -224,7 +217,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "ignore line break outside of table" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -235,8 +228,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       Hello +
       This is a line break
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -254,7 +246,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "deals with non-Ascii characters" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -264,8 +256,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       Hello René! Hello Владимир!
 
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -282,7 +273,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "deals with HTML entities" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -295,8 +286,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 2
       Hello &lt;&nbsp;(&amp;lt;)
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>

--- a/spec/asciidoctor/rfc/v3/keyword_spec.rb
+++ b/spec/asciidoctor/rfc/v3/keyword_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders keywords" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>

--- a/spec/asciidoctor/rfc/v3/link_spec.rb
+++ b/spec/asciidoctor/rfc/v3/link_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders links" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/paragraph_spec.rb
+++ b/spec/asciidoctor/rfc/v3/paragraph_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "suppresses smart apostrophes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -30,15 +30,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Dante's Revenge
       Don't panic!
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-       <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-       <?rfc strict="yes"?>
-       <?rfc toc="yes"?>
-       <?rfc tocdepth="4"?>
-       <?rfc symrefs=""?>
-       <?rfc sortrefs=""?>
-       <?rfc compact="yes"?>
-       <?rfc subcompact="no"?>
+       #{XML_HDR}
        <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
          <title abbrev="abbrev_value">Document title</title>

--- a/spec/asciidoctor/rfc/v3/preamble_spec.rb
+++ b/spec/asciidoctor/rfc/v3/preamble_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders no abstract if preamble has no content" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -9,8 +9,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -29,7 +28,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders preamble contents as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -41,8 +40,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -65,7 +63,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders admonitions in preamble as notes, following an abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -81,8 +79,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
@@ -105,7 +102,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders unordered lists in preamble as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -116,8 +113,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -142,7 +138,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders ordered lists in preamble as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -153,8 +149,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -179,7 +174,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders definition lists in preamble as abstract" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -189,8 +184,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -215,7 +209,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "renders admonitions in preamble as notes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :docName:
@@ -231,8 +225,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Lorem
       Ipsum.
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">

--- a/spec/asciidoctor/rfc/v3/references_spec.rb
+++ b/spec/asciidoctor/rfc/v3/references_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders raw RFC XML as references, with displayreferences" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: internet-draft
@@ -114,15 +114,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-       <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-       <?rfc strict="yes"?>
-       <?rfc toc="yes"?>
-       <?rfc tocdepth="4"?>
-       <?rfc symrefs=""?>
-       <?rfc sortrefs=""?>
-       <?rfc compact="yes"?>
-       <?rfc subcompact="no"?>
+       #{XML_HDR}
        <rfc submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
          <title>Document title</title>
@@ -147,7 +139,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders external RFC XML references as includes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -200,15 +192,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
+      #{XML_HDR}
       <rfc xmlns:xi="http://www.w3.org/2001/XInclude" submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
          <title>The Holy Hand Grenade of Antioch</title>
@@ -234,7 +218,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders skeletal external RFC XML references as includes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -266,15 +250,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
+      #{XML_HDR}
       <rfc xmlns:xi="http://www.w3.org/2001/XInclude" submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
          <title>The Holy Hand Grenade of Antioch</title>
@@ -301,7 +277,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders skeletal external RFC XML references with drafts as includes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true).to_s).to be_equivalent_to <<~"OUTPUT"
       = The Holy Hand Grenade of Antioch
       Arthur Pendragon
       :doctype: internet-draft
@@ -322,15 +298,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       </reference>
       ++++
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-      <?rfc strict="yes"?>
-      <?rfc compact="yes"?>
-      <?rfc subcompact="no"?>
-      <?rfc toc="yes"?>
-      <?rfc tocdepth="4"?>
-      <?rfc symrefs="yes"?>
-      <?rfc sortrefs="yes"?>
+      #{XML_HDR}
       <rfc xmlns:xi="http://www.w3.org/2001/XInclude" submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
       <front>
          <title>The Holy Hand Grenade of Antioch</title>

--- a/spec/asciidoctor/rfc/v3/section_spec.rb
+++ b/spec/asciidoctor/rfc/v3/section_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders section with attributes" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -13,8 +13,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -35,7 +34,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders subsections" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -58,8 +57,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       ==== Subsection 1.2.1
       Para 3
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -91,7 +89,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "ignores page breaks" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -104,8 +102,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -126,7 +123,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "ignores horizontal rules" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -139,8 +136,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
 
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -161,7 +157,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "renders floating titles" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -174,8 +170,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 2
       Para 2
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IETF">
@@ -197,7 +192,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
   end
 
   it "supresses natural cross-references" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :abbrev: abbrev_value
       :docName:
@@ -218,16 +213,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       ...
       ++++
     INPUT
-    <?xml version="1.0" encoding="US-ASCII"?>
-<?xml-stylesheet type="text/xsl" href="rfc2629.xslt"?>
-<!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-<?rfc strict="yes"?>
-<?rfc compact="yes"?>
-<?rfc subcompact="no"?>
-<?rfc toc="yes"?>
-<?rfc tocdepth="4"?>
-<?rfc symrefs="yes"?>
-<?rfc sortrefs="yes"?>
+      #{XML_HDR}
        <rfc xmlns:xi="http://www.w3.org/2001/XInclude" submissionType="IETF" prepTime="2000-01-01T05:00:00Z" version="3">
        <front>
          <title abbrev="abbrev_value">Document title</title>

--- a/spec/asciidoctor/rfc/v3/series_info_spec.rb
+++ b/spec/asciidoctor/rfc/v3/series_info_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "sets seriesInfo attributes for Internet Draft" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: internet-draft
@@ -13,8 +13,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IRTF">
@@ -38,7 +37,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "sets seriesInfo attributes for RFC, with FYI status" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: rfc
@@ -50,8 +49,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IRTF">
@@ -75,7 +73,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "treats the rfc- prefix on :name: as optional" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: rfc
@@ -87,8 +85,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IRTF">
@@ -112,7 +109,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "sets seriesInfo attributes for RFC with historic status" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: rfc
@@ -124,8 +121,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z"
                 version="3" submissionType="IRTF">
@@ -149,7 +145,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
     OUTPUT
   end
   it "sets seriesInfo attributes for RFC with illegal intended status" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       Author
       :doctype: internet-draft
@@ -161,29 +157,22 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-       <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
-       <?rfc strict="yes"?>
-       <?rfc toc="yes"?>
-       <?rfc tocdepth="4"?>
-       <?rfc symrefs=""?>
-       <?rfc sortrefs=""?>
-       <?rfc compact="yes"?>
-       <?rfc subcompact="no"?>
-       <rfc submissionType="IRTF" prepTime="2000-01-01T05:00:00Z" version="3">
-       <front>
-         <title>Document title</title>
-         <seriesInfo name="Internet-Draft" status="full-standard" stream="IRTF" value="draft-xxx"/>
-         <seriesInfo name="" status="illegal" value="draft-xxx"/>
-         <author fullname="Author"/>
-         <date day="1" month="January" year="2000"/>
+      #{XML_HDR}
+      <rfc submissionType="IRTF" prepTime="2000-01-01T05:00:00Z" version="3">
+        <front>
+          <title>Document title</title>
+          <seriesInfo name="Internet-Draft" status="full-standard" stream="IRTF" value="draft-xxx"/>
+          <seriesInfo name="" status="illegal" value="draft-xxx"/>
+          <author fullname="Author"/>
+          <date day="1" month="January" year="2000"/>
 
-       </front><middle>
-       <section anchor="_section_1" numbered="false">
-         <name>Section 1</name>
-         <t>Text</t>
-       </section>
-       </middle>
+        </front>
+        <middle>
+          <section anchor="_section_1" numbered="false">
+            <name>Section 1</name>
+            <t>Text</t>
+          </section>
+        </middle>
       </rfc>
     OUTPUT
   end

--- a/spec/asciidoctor/rfc/v3/workgroup_spec.rb
+++ b/spec/asciidoctor/rfc/v3/workgroup_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe Asciidoctor::Rfc::V3::Converter do
   it "renders workgroups" do
-    expect(Asciidoctor.convert(<<~'INPUT', backend: :rfc3, header_footer: true)).to be_equivalent_to <<~'OUTPUT'
+    expect(Asciidoctor.convert(<<~"INPUT", backend: :rfc3, header_footer: true)).to be_equivalent_to <<~"OUTPUT"
       = Document title
       :docName:
       Author
@@ -10,8 +10,7 @@ RSpec.describe Asciidoctor::Rfc::V3::Converter do
       == Section 1
       Text
     INPUT
-      <?xml version="1.0" encoding="US-ASCII"?>
-      <!DOCTYPE rfc SYSTEM "rfc2629.dtd">
+      #{XML_HDR}
 
       <rfc prepTime="2000-01-01T05:00:00Z" version="3" submissionType="IETF">
       <front>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,10 @@ def strip_guid(x)
   x.gsub(%r{ id="_[^"]+"}, ' id="_"').gsub(%r{ target="_[^"]+"}, ' target="_"')
 end
 
+def dtd_absolute_path
+  File.join(File.expand_path('..', File.dirname(__FILE__)), "rfc2629.dtd")
+end
+
 ASCIIDOC_BLANK_HDR = <<~"HDR"
       = Document title
       Author
@@ -120,3 +124,15 @@ HTML_HDR = <<~"HDR"
            <div class="main-section">
 HDR
 
+XML_HDR = <<~"HDR"
+      <?xml version="1.0" encoding="US-ASCII"?>
+      <?xml-stylesheet type="text/xsl" href="rfc2629.xslt"?>
+      <!DOCTYPE rfc SYSTEM "#{dtd_absolute_path}">
+      <?rfc strict="yes"?>
+      <?rfc compact="yes"?>
+      <?rfc subcompact="no"?>
+      <?rfc toc="yes"?>
+      <?rfc tocdepth="4"?>
+      <?rfc symrefs="yes"?>
+      <?rfc sortrefs="yes"?>
+HDR


### PR DESCRIPTION
 - https://github.com/metanorma/mn-templates-ietf/pull/3