### PR TITLE
Bug fixes for verison 2.0.6

### DIFF
--- a/lib/isodoc/ietf/inline.rb
+++ b/lib/isodoc/ietf/inline.rb
@@ -106,7 +106,16 @@ module IsoDoc::Ietf
     def xref_parse(node, out)
       out.xref **attr_code(target: node["target"], format: node["format"],
                            relative: node["relative"]) do |l|
-                             l << get_linkend(node)
+                             l2 = get_linkend(node)
+                             if l2.start_with? "Annex" then
+                               l << ""
+                             elsif l2.start_with? "Clause" then
+                               l << ""
+                             elsif l2.start_with? "IETF" then
+                               l << ""
+                             else
+                               l << get_linkend(node)
+                             end
                            end
     end
 

--- a/lib/isodoc/ietf/section.rb
+++ b/lib/isodoc/ietf/section.rb
@@ -75,8 +75,6 @@ module IsoDoc::Ietf
         'xml:lang':     docxml&.at(ns("//bibdata/language"))&.text,
         version:        "3",
         'xmlns:xi':        "http://www.w3.org/2001/XInclude",
-        prepTime:       sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ",
-                                t.year, t.month, t.day, t.hour, t.min, t.sec),
       }
     end
 
@@ -114,8 +112,8 @@ module IsoDoc::Ietf
 
     def make_back(out, isoxml)
       out.back do |back|
-        annex isoxml, back
         bibliography isoxml, back
+        annex isoxml, back
       end
     end
 

--- a/lib/metanorma/ietf/processor.rb
+++ b/lib/metanorma/ietf/processor.rb
@@ -17,7 +17,8 @@ module Metanorma
           xml: "xml",
           rfc: "rfc.xml",
           html: "html",
-          txt: "txt"
+          txt: "txt",
+          pdf: "pdf"
         }
       end
 
@@ -53,8 +54,8 @@ module Metanorma
           IsoDoc::Ietf::RfcConvert.new(options).convert(outname.sub(/\.xml/, ""), isodoc_node)
           @done_rfc = true
 
-        when :txt, :html
-          rfcname = outname.sub(/\.(html|txt)$/, ".rfc.xml")
+        when :txt, :html, :pdf
+          rfcname = outname.sub(/\.(html|txt|pdf)$/, ".rfc.xml")
           output(isodoc_node, outname, :rfc, options) unless @done_rfc
           unless which("xml2rfc")
             warn "[metanorma-ietf] Error: unable to generate #{format}, the command `xml2rfc` is not found in path."


### PR DESCRIPTION
- Do not add content in xref.
- Process "src" uri in reference.
- Process DOI and IETF docidentifiers in references.
- Do not prenped the identifier.
- Annex goes after the bibliography.
- Remove prepTime.
- Always keep the xml references.
- Add <t> in abstract of references.
- Output pdf files.