### PR TITLE
Bug fixes for verison 2.0.6 from @petithug

### DIFF
--- a/lib/asciidoctor/ietf/converter.rb
+++ b/lib/asciidoctor/ietf/converter.rb
@@ -22,6 +22,7 @@ module Asciidoctor
         @draft = node.attributes.has_key?("draft")
         @workgroups = cache_workgroup(node)
         @bcp_bold = !node.attr?("no-rfc-bold-bcp14")
+        @xinclude = node.attr?("use-xinclude") 
         super
       end
 
@@ -196,6 +197,10 @@ module Asciidoctor
             xref_to_eref(x)
           end
         end
+      end
+
+      def html_extract_attributes(node)
+        super.merge(use_xinclude: node.attr("use-xinclude"))
       end
 
       def rfc_converter(node)

--- a/lib/isodoc/ietf/inline.rb
+++ b/lib/isodoc/ietf/inline.rb
@@ -106,7 +106,7 @@ module IsoDoc::Ietf
     def xref_parse(node, out)
       out.xref **attr_code(target: node["target"], format: node["format"],
                            relative: node["relative"]) do |l|
-                             l2 << get_linkend(node)
+                             l << get_linkend(node)
                            end
     end
 
@@ -115,6 +115,7 @@ module IsoDoc::Ietf
         select { |c| !c.text? || /\S/.match(c) }
       !contents.empty? and
         return Nokogiri::XML::NodeSet.new(node.document, contents).to_xml
+      ""
     end
 
     def eref_parse(node, out)

--- a/lib/isodoc/ietf/inline.rb
+++ b/lib/isodoc/ietf/inline.rb
@@ -106,7 +106,16 @@ module IsoDoc::Ietf
     def xref_parse(node, out)
       out.xref **attr_code(target: node["target"], format: node["format"],
                            relative: node["relative"]) do |l|
-                             l << get_linkend(node)
+                             l2 = get_linkend(node)
+                             if l2.start_with? "Annex" then
+                               l << ""
+                             elsif l2.start_with? "Clause" then
+                               l << ""
+                             elsif l2.start_with? "IETF" then
+                               l << ""
+                             else
+                               l << get_linkend(node)
+                             end
                            end
     end
 

--- a/lib/isodoc/ietf/inline.rb
+++ b/lib/isodoc/ietf/inline.rb
@@ -106,17 +106,15 @@ module IsoDoc::Ietf
     def xref_parse(node, out)
       out.xref **attr_code(target: node["target"], format: node["format"],
                            relative: node["relative"]) do |l|
-                             l2 = get_linkend(node)
-                             if l2.start_with? "Annex" then
-                               l << ""
-                             elsif l2.start_with? "Clause" then
-                               l << ""
-                             elsif l2.start_with? "IETF" then
-                               l << ""
-                             else
-                               l << get_linkend(node)
-                             end
+                             l2 << get_linkend(node)
                            end
+    end
+
+    def get_linkend(node)
+      contents = node.children.select { |c| !%w{locality localityStack}.include? c.name }.
+        select { |c| !c.text? || /\S/.match(c) }
+      !contents.empty? and
+        return Nokogiri::XML::NodeSet.new(node.document, contents).to_xml
     end
 
     def eref_parse(node, out)

--- a/lib/isodoc/ietf/rfc_convert.rb
+++ b/lib/isodoc/ietf/rfc_convert.rb
@@ -61,5 +61,10 @@ module IsoDoc::Ietf
       filename = filename.sub(/\.rfc\.xml$/, ".rfc")
       super
     end
+
+    def initialize(options)
+      super
+      @xinclude = options[:use_xinclude] == "true"
+    end
   end
 end

--- a/lib/isodoc/ietf/section.rb
+++ b/lib/isodoc/ietf/section.rb
@@ -75,8 +75,6 @@ module IsoDoc::Ietf
         'xml:lang':     docxml&.at(ns("//bibdata/language"))&.text,
         version:        "3",
         'xmlns:xi':        "http://www.w3.org/2001/XInclude",
-        prepTime:       sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ",
-                                t.year, t.month, t.day, t.hour, t.min, t.sec),
       }
     end
 
@@ -114,8 +112,8 @@ module IsoDoc::Ietf
 
     def make_back(out, isoxml)
       out.back do |back|
-        annex isoxml, back
         bibliography isoxml, back
+        annex isoxml, back
       end
     end
 

--- a/lib/metanorma/ietf/processor.rb
+++ b/lib/metanorma/ietf/processor.rb
@@ -17,7 +17,8 @@ module Metanorma
           xml: "xml",
           rfc: "rfc.xml",
           html: "html",
-          txt: "txt"
+          txt: "txt",
+          pdf: "pdf"
         }
       end
 
@@ -53,8 +54,8 @@ module Metanorma
           IsoDoc::Ietf::RfcConvert.new(options).convert(outname.sub(/\.xml/, ""), isodoc_node)
           @done_rfc = true
 
-        when :txt, :html
-          rfcname = outname.sub(/\.(html|txt)$/, ".rfc.xml")
+        when :txt, :html, :pdf
+          rfcname = outname.sub(/\.(html|txt|pdf)$/, ".rfc.xml")
           output(isodoc_node, outname, :rfc, options) unless @done_rfc
           unless which("xml2rfc")
             warn "[metanorma-ietf] Error: unable to generate #{format}, the command `xml2rfc` is not found in path."

--- a/spec/isodoc/cleanup_spec.rb
+++ b/spec/isodoc/cleanup_spec.rb
@@ -3,7 +3,7 @@ require "nokogiri"
 RSpec.describe IsoDoc::Ietf::RfcConvert do
   it "cleans up footnotes" do
     expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).cleanup(Nokogiri::XML(<<~"INPUT")).to_s)).to be_equivalent_to xmlpp(<<~"OUTPUT")
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front>
            <abstract>
              <t>
@@ -34,7 +34,7 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
          <back/>
        </rfc>
 INPUT
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front>
            <abstract>
              <t> A. [1] </t>
@@ -56,7 +56,7 @@ INPUT
 
   it "cleans up footnotes in a section" do
     expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).cleanup(Nokogiri::XML(<<~"INPUT")).to_s)).to be_equivalent_to xmlpp(<<~"OUTPUT")
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front/>
          <middle>
            <section>
@@ -92,7 +92,7 @@ INPUT
          </back>
        </rfc>
 INPUT
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front/>
          <middle>
            <section>
@@ -265,7 +265,7 @@ INPUT
 
   it "cleans up figures" do
     expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).cleanup(Nokogiri::XML(<<~"INPUT")).to_s)).to be_equivalent_to xmlpp(<<~"OUTPUT")
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front>
            <abstract>
      <figure anchor='figureA-0'>
@@ -319,7 +319,7 @@ INPUT
          <back/>
        </rfc>
        INPUT
-       <rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+       <rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front>
            <abstract>
            <figure anchor='figureA-0'>
@@ -459,7 +459,7 @@ OUTPUT
 
    it "cleans up annotated bibliography" do
       expect((IsoDoc::Ietf::RfcConvert.new({}).cleanup(Nokogiri::XML(<<~"INPUT")).to_s)).to be_equivalent_to (<<~"OUTPUT")
-      <rfc xmlns:xi='http://www.w3.org/2001/XInclude' xml:lang='en' version='3' prepTime='2000-01-01T05:00:00Z'>
+      <rfc xmlns:xi='http://www.w3.org/2001/XInclude' xml:lang='en' version='3'>
          <front>
            <abstract>
              <t anchor='_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f'>
@@ -579,7 +579,7 @@ OUTPUT
          </back>
        </rfc>
       INPUT
-      <rfc xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en" version="3" prepTime="2000-01-01T05:00:00Z">
+      <rfc xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en" version="3">
           <front>
             <abstract>
               <t anchor="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">
@@ -708,7 +708,7 @@ OUTPUT
 
      it "cleans up definition lists" do
     expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).cleanup(Nokogiri::XML(<<~"INPUT")).to_s)).to be_equivalent_to xmlpp(<<~"OUTPUT")
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
          <front>
            <abstract>
            <t id="id0"><bookmark anchor="id1"/>A</t>
@@ -724,7 +724,7 @@ OUTPUT
          <back/>
        </rfc>
 INPUT
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' version='3'>
   <front>
     <abstract>
     <t id='id0'>A</t>

--- a/spec/isodoc/inline_spec.rb
+++ b/spec/isodoc/inline_spec.rb
@@ -183,6 +183,75 @@ $$ Latex? $$
     OUTPUT
   end
 
+    it "cross-references notes" do
+    expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).convert("test", <<~"INPUT", true))).to be_equivalent_to xmlpp(<<~"OUTPUT")
+    <iso-standard xmlns="http://riboseinc.com/isoxml">
+    <preface>
+    <foreword>
+    <p>
+    <xref target="N1">note</xref>
+    <xref target="N2"/>
+    <xref target="N"/>
+    <xref target="note1"/>
+    <xref target="note2">note</xref>
+    <xref target="AN"/>
+    <xref target="Anote1">note</xref>
+    <xref target="Anote2"/>
+    </p>
+    </foreword>
+    <introduction id="intro">
+    <note id="N1">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83e">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+<clause id="xyz"><title>Preparatory</title>
+    <note id="N2">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83d">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+</clause>
+    </introduction>
+    </preface>
+    <sections>
+    <clause id="scope"><title>Scope</title>
+    <note id="N">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+<p><xref target="N"/></p>
+
+    </clause>
+    <terms id="terms"/>
+    <clause id="widgets"><title>Widgets</title>
+    <clause id="widgets1">
+    <note id="note1">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+    <note id="note2">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83a">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+<p>    <xref target="note1"/> <xref target="note2"/> </p>
+
+    </clause>
+    </clause>
+    </sections>
+    <annex id="annex1">
+    <clause id="annex1a">
+    <note id="AN">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+    </clause>
+    <clause id="annex1b">
+    <note id="Anote1">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+    <note id="Anote2">
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83a">These results are based on a study carried out on three different types of kernel.</p>
+</note>
+    </clause>
+    </annex>
+    </iso-standard>
+INPUT
+OUTPUT
+    end
+
   it "processes eref attributes" do
     expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({}).convert("test", <<~"INPUT", true))).to be_equivalent_to xmlpp(<<~"OUTPUT")
     <iso-standard xmlns="http://riboseinc.com/isoxml">

--- a/spec/isodoc/inline_spec.rb
+++ b/spec/isodoc/inline_spec.rb
@@ -249,6 +249,99 @@ $$ Latex? $$
     </annex>
     </iso-standard>
 INPUT
+    #{XML_HDR}
+             <t>
+               <xref target='N1'>note</xref>
+               <xref target='N2'/>
+               <xref target='N'/>
+               <xref target='note1'/>
+               <xref target='note2'>note</xref>
+               <xref target='AN'/>
+               <xref target='Anote1'>note</xref>
+               <xref target='Anote2'/>
+             </t>
+           </abstract>
+         </front>
+         <middle>
+           <section anchor='intro'>
+             <aside anchor='N1'>
+               <t>
+                 NOTE: These results are based on a study carried out on three
+                 different types of kernel.
+               </t>
+             </aside>
+             <section anchor='xyz'>
+               <name>Preparatory</name>
+               <aside anchor='N2'>
+                 <t>
+                   NOTE: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+             </section>
+           </section>
+           <section anchor='scope'>
+             <name>Scope</name>
+             <aside anchor='N'>
+               <t>
+                 NOTE: These results are based on a study carried out on three
+                 different types of kernel.
+               </t>
+             </aside>
+             <t>
+               <xref target='N'/>
+             </t>
+           </section>
+           <section anchor='terms'/>
+           <section anchor='widgets'>
+             <name>Widgets</name>
+             <section anchor='widgets1'>
+               <aside anchor='note1'>
+                 <t>
+                   NOTE 1: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+               <aside anchor='note2'>
+                 <t>
+                   NOTE 2: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+               <t>
+                 <xref target='note1'/>
+                 <xref target='note2'/>
+               </t>
+             </section>
+           </section>
+         </middle>
+         <back>
+           <section anchor='annex1'>
+             <section anchor='annex1a'>
+               <aside anchor='AN'>
+                 <t>
+                   NOTE: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+             </section>
+             <section anchor='annex1b'>
+               <aside anchor='Anote1'>
+                 <t>
+                   NOTE 1: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+               <aside anchor='Anote2'>
+                 <t>
+                   NOTE 2: These results are based on a study carried out on three
+                   different types of kernel.
+                 </t>
+               </aside>
+             </section>
+           </section>
+         </back>
+       </rfc>
 OUTPUT
     end
 
@@ -285,11 +378,12 @@ OUTPUT
     <name>Normative References</name>
     <reference anchor='ISO712'>
       <front>
-        <title>ISO 712, Cereals and cereal products</title>
-        <author>
-  <organization abbrev='ISO'/>
-</author>
-      </front>
+  <title>Cereals and cereal products</title>
+  <author>
+    <organization abbrev='ISO'/>
+  </author>
+</front>
+<refcontent>ISO 712</refcontent>
     </reference>
   </references>
 </back>
@@ -354,11 +448,12 @@ OUTPUT
     <name>Normative References</name>
     <reference anchor='ISO712'>
       <front>
-        <title>ISO 712, Cereals and cereal products</title>
-        <author>
-  <organization abbrev='ISO'/>
-</author>
-      </front>
+  <title>Cereals and cereal products</title>
+  <author>
+    <organization abbrev='ISO'/>
+  </author>
+</front>
+<refcontent>ISO 712</refcontent>
     </reference>
   </references>
 </back>

--- a/spec/isodoc/metadata_spec.rb
+++ b/spec/isodoc/metadata_spec.rb
@@ -311,7 +311,7 @@ INPUT
 <?rfc tocdepth="4"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' number='1000' category='BCP' ipr='noModificationTrust200902,pre5378Trust200902' obsoletes='OB1, OB2' updates='UPD1, UPD2' indexInclude='false' iprExtract='Section 3' sortRefs='false' symRefs='false' tocInclude='false' tocDepth='9' submissionType='IRTF' xml:lang='en' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' number='1000' category='BCP' ipr='noModificationTrust200902,pre5378Trust200902' obsoletes='OB1, OB2' updates='UPD1, UPD2' indexInclude='false' iprExtract='Section 3' sortRefs='false' symRefs='false' tocInclude='false' tocDepth='9' submissionType='IRTF' xml:lang='en' version='3'>
          <link href='INC1' rel='item'/>
          <link href='INCL2' rel='item'/>
          <link href='DESC1' rel='describedby'/>
@@ -479,7 +479,7 @@ INPUT
         <?rfc tocdepth="4"?>
         <?rfc symrefs="yes"?>
         <?rfc sortrefs="yes"?>
-        <rfc xmlns:xi='http://www.w3.org/2001/XInclude' docName='1000' category='BCP' submissionType='IETF' xml:lang='el' version='3' prepTime='2000-01-01T05:00:00Z'>
+        <rfc xmlns:xi='http://www.w3.org/2001/XInclude' docName='1000' category='BCP' submissionType='IETF' xml:lang='el' version='3'>
           <front>
             <title ascii='Document title'>Document title</title>
             <seriesInfo value='1000' asciiValue='1000' status='Published' stream='IETF' name='Internet-Draft' asciiName='Internet-Draft'/>

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe IsoDoc::Ietf do
   <uri>http://www.example.com</uri>
   <uri type="RDF">http://www.example.com/rdf</uri>
   <docidentifier type="ISO">ISO 16634:-- (all parts)</docidentifier>
+  <docidentifier type="DOI">1234</docidentifier>
   <date type="published"><on>--</on></date>
   <contributor>
     <role type="publisher"/>
@@ -86,6 +87,7 @@ RSpec.describe IsoDoc::Ietf do
   <initial>B.</initial>
   </person>
 </contributor>
+  <abstract>This is an abstract</abstract>
 </bibitem>
 <bibitem id="ref1">
   <formattedref format="application/x-isodoc+xml"><smallcap>Standard No I.C.C 167</smallcap>. <em>Determination of the protein content in cereal and cereal products for food and animal feeding stuffs according to the Dumas combustion method</em> (see <link target="http://www.icc.or.at"/>)</formattedref>
@@ -150,14 +152,14 @@ RSpec.describe IsoDoc::Ietf do
     </iso-standard>
     INPUT
            #{XML_HDR}
-             <t anchor='_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f'>
-               <relref target='ISO712'  section=''/>
-               <relref target='ISBN'  section=''/>
-               <relref target='ISSN'  section=''/>
-               <relref target='ISO16634'  section=''/>
-               <relref target='ref1'  section=''/>
-               <relref target='ref10'  section=''/>
-               <relref target='ref12'  section=''/>
+           <t anchor='_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f'>
+               <relref target='ISO712' section=''/>
+               <relref target='ISBN' section=''/>
+               <relref target='ISSN' section=''/>
+               <relref target='ISO16634' section=''/>
+               <relref target='ref1' section=''/>
+               <relref target='ref10' section=''/>
+               <relref target='ref12' section=''/>
              </t>
            </abstract>
          </front>
@@ -165,19 +167,21 @@ RSpec.describe IsoDoc::Ietf do
          <back>
            <references anchor='_normative_references'>
              <name>Normative References</name>
-             <reference target='http://www.example.com' anchor='ISO712'>
+             <reference anchor='ISO712'>
                <front>
-                 <title>ISO 712, Cereals or cereal products</title>
+                 <title>Cereals or cereal products</title>
                  <author>
-  <organization ascii='International Organization for Standardization'>International Organization for Standardization</organization>
-</author>
+                   <organization ascii='International Organization for Standardization'>International Organization for Standardization</organization>
+                 </author>
                </front>
+               <format target='http://www.example.com'/>
+               <refcontent>ISO 712</refcontent>
              </reference>
-             <reference target='http://www.example.com' anchor='ISO16634'>
+             <reference anchor='ISO16634'>
                <front>
                  <title>
-                   ISO 16634:-- (all parts), Cereals, pulses, milled cereal products,
-                   xxxx, oilseeds and animal feeding stuffs
+                   Cereals, pulses, milled cereal products, xxxx, oilseeds and animal
+                   feeding stuffs
                  </title>
                  <author>
                    <organization ascii='International Supporters of Odium' abbrev='ISO1'>International Supporters of Odium</organization>
@@ -188,22 +192,82 @@ RSpec.describe IsoDoc::Ietf do
                    <t>This is an abstract</t>
                  </abstract>
                </front>
+               <format target='http://www.example.com'/>
                <format target='http://www.example.com/rdf' type='RDF'/>
+               <refcontent>ISO 16634:-- (all parts)</refcontent>
+<seriesInfo value='1234' name='DOI'/>
              </reference>
              <reference anchor='ISO20483'>
                <front>
-                 <title>ISO 20483:2013-2014, Cereals and pulses</title>
+                 <title>Cereals and pulses</title>
                  <author fullname='&#xD6;laf N&#xFC;rk' asciiFullname='Olaf Nurk' surname='N&#xFC;rk' asciiSurname='Nurk'/>
                  <author>
                    <organization/>
                  </author>
                  <date year='2013'/>
+                 <abstract>
+                   <t>This is an abstract</t>
+                 </abstract>
                </front>
+               <refcontent>ISO 20483:2013-2014</refcontent>
              </reference>
              <reference anchor='ref1'>
                <front>
                  <title>
-                   ICC 167, Standard No I.C.C 167.
+                   Standard No I.C.C 167.
+                   <em>
+                     Determination of the protein content in cereal and cereal products
+                     for food and animal feeding stuffs according to the Dumas
+                     combustion method
+                   </em>
+                    (see
+                   <eref target='http://www.icc.or.at'/>
+                   )
+                 </title>
+               </front>
+               <refcontent>ICC 167</refcontent>
+             </reference>
+             <aside>
+               <t>NOTE: This is an annotation of ISO 20483:2013-2014</t>
+             </aside>
+           </references>
+           <references anchor='_bibliography'>
+             <name>Bibliography</name>
+             <reference anchor='ISBN'>
+               <front>
+                 <title>Chemicals for analytical laboratory use</title>
+                 <author>
+                   <organization abbrev='ISBN'/>
+                 </author>
+               </front>
+             </reference>
+             <reference anchor='ISSN'>
+               <front>
+                 <title>Instruments for analytical laboratory use</title>
+                 <author>
+                   <organization abbrev='ISSN'/>
+                 </author>
+               </front>
+             </reference>
+             <aside>
+               <t>NOTE: This is an annotation of document ISSN.</t>
+             </aside>
+             <aside>
+               <t>NOTE: This is another annotation of document ISSN.</t>
+             </aside>
+             <reference anchor='ISO3696'>
+               <front>
+                 <title>Water for analytical laboratory use</title>
+                 <author>
+                   <organization ascii='International Standards Organization' abbrev='ISO'>International Standards Organization</organization>
+                 </author>
+               </front>
+               <refcontent>ISO 3696</refcontent>
+             </reference>
+             <reference anchor='ref10'>
+               <front>
+                 <title>
+                   Standard No I.C.C 167.
                    <em>
                      Determination of the protein content in cereal and cereal products
                      for food and animal feeding stuffs according to the Dumas
@@ -215,6 +279,255 @@ RSpec.describe IsoDoc::Ietf do
                  </title>
                </front>
              </reference>
+             <reference anchor='ref11'>
+               <front>
+                 <title>Internet Calendaring and Scheduling Core Object Specification (iCalendar)</title>
+               </front>
+               <format target='https://xml2rfc.tools.ietf.org/10.xml' type='xml'/>
+               <seriesInfo value='RFC 10' name='IETF'/>
+             </reference>
+             <reference anchor='ref12'>
+               <front>
+                 <title>
+                   CitationWorks. 2019.
+                   <em>How to cite a reference</em>
+                   .
+                 </title>
+               </front>
+             </reference>
+           </references>
+         </back>
+       </rfc>
+
+    OUTPUT
+  end
+
+  it "processes IsoXML bibliographies with xincludes" do
+    expect(xmlpp(IsoDoc::Ietf::RfcConvert.new({use_xinclude: "true"}).convert("test", <<~"INPUT", true))).to be_equivalent_to xmlpp(<<~"OUTPUT")
+    <iso-standard xmlns="http://riboseinc.com/isoxml">
+    <bibdata>
+    </bibdata>
+    <preface><foreword>
+  <p id="_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f">
+  <eref bibitemid="ISO712"/>
+  <eref bibitemid="ISBN"/>
+  <eref bibitemid="ISSN"/>
+  <eref bibitemid="ISO16634"/>
+  <eref bibitemid="ref1"/>
+  <eref bibitemid="ref10"/>
+  <eref bibitemid="ref12"/>
+  </p>
+    </foreword></preface>
+    <bibliography><references id="_normative_references" obligation="informative"><title>Normative References</title>
+<bibitem id="ISO712" type="standard">
+  <title format="text/plain">Cereals or cereal products</title>
+  <title type="main" format="text/plain">Cereals and cereal products</title>
+  <uri>http://www.example.com</uri>
+  <docidentifier type="ISO">ISO 712</docidentifier>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>International Organization for Standardization</name>
+    </organization>
+  </contributor>
+</bibitem>
+<bibitem id="ISO16634" type="standard">
+  <title language="x" format="text/plain">Cereals, pulses, milled cereal products, xxxx, oilseeds and animal feeding stuffs</title>
+  <title language="en" format="text/plain">Cereals, pulses, milled cereal products, oilseeds and animal feeding stuffs</title>
+  <uri>http://www.example.com</uri>
+  <uri type="RDF">http://www.example.com/rdf</uri>
+  <docidentifier type="ISO">ISO 16634:-- (all parts)</docidentifier>
+  <docidentifier type="DOI">1234</docidentifier>
+  <date type="published"><on>--</on></date>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <abbreviation>ISO</abbreviation>
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="editor"/>
+    <organization>
+      <name>International Supporters of Odium</name>
+      <abbreviation>ISO1</abbreviation>
+    </organization>
+  </contributor>
+  <keyword>keyword1</keyword>
+  <keyword>keyword2</keyword>
+  <abstract><p>This is an abstract</p></abstract>
+  <note format="text/plain" reference="1">ISO DATE: Under preparation. (Stage at the time of publication ISO/DIS 16634)</note>
+  <extent type="part">
+  <referenceFrom>all</referenceFrom>
+  </extent>
+
+</bibitem>
+<bibitem id="ISO20483" type="standard">
+  <title format="text/plain">Cereals and pulses</title>
+  <docidentifier type="ISO">ISO 20483:2013-2014</docidentifier>
+  <date type="published"><from>2013</from><to>2014</to></date>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>International Organization for Standardization</name>
+    </organization>
+  </contributor>
+  <contributor>
+  <role type="author"/>
+  <person>
+  <name><completename>Ölaf Nürk</ompletename>
+  <surname>Nürk</surname>
+  <forename>Ölaf</forename>
+  </name>
+  </person>
+</contributor>
+<contributor>
+  <role type="author"/>
+  <person>
+  <surname>Citizen</surname>
+  <initial>A.</initial>
+  <initial>B.</initial>
+  </person>
+</contributor>
+  <abstract>This is an abstract</abstract>
+</bibitem>
+<bibitem id="ref1">
+  <formattedref format="application/x-isodoc+xml"><smallcap>Standard No I.C.C 167</smallcap>. <em>Determination of the protein content in cereal and cereal products for food and animal feeding stuffs according to the Dumas combustion method</em> (see <link target="http://www.icc.or.at"/>)</formattedref>
+  <docidentifier type="ICC">167</docidentifier>
+</bibitem>
+<note><p>This is an annotation of ISO 20483:2013-2014</p></note>
+
+</references><references id="_bibliography" obligation="informative">
+  <title>Bibliography</title>
+<bibitem id="ISBN" type="ISBN">
+  <title format="text/plain">Chemicals for analytical laboratory use</title>
+  <docidentifier type="ISBN">ISBN</docidentifier>
+  <docidentifier type="metanorma">[1]</docidentifier>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <abbreviation>ISBN</abbreviation>
+    </organization>
+  </contributor>
+</bibitem>
+<bibitem id="ISSN" type="ISSN">
+  <title format="text/plain">Instruments for analytical laboratory use</title>
+  <docidentifier type="ISSN">ISSN</docidentifier>
+  <docidentifier type="metanorma">[2]</docidentifier>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <abbreviation>ISSN</abbreviation>
+    </organization>
+  </contributor>
+</bibitem>
+<note><p>This is an annotation of document ISSN.</p></note>
+<note><p>This is another annotation of document ISSN.</p></note>
+<bibitem id="ISO3696" type="standard">
+  <title format="text/plain">Water for analytical laboratory use</title>
+  <docidentifier type="ISO">ISO 3696</docidentifier>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+    <name>International Standards Organization</name>
+      <abbreviation>ISO</abbreviation>
+    </organization>
+  </contributor>
+</bibitem>
+<bibitem id="ref10">
+  <formattedref format="application/x-isodoc+xml"><smallcap>Standard No I.C.C 167</smallcap>. <em>Determination of the protein content in cereal and cereal products for food and animal feeding stuffs according to the Dumas combustion method</em> (see <link target="http://www.icc.or.at"/>)</formattedref>
+  <docidentifier type="metanorma">[10]</docidentifier>
+</bibitem>
+<bibitem id="ref11">
+  <title>Internet Calendaring and Scheduling Core Object Specification (iCalendar)</title>
+  <docidentifier type="IETF">RFC 10</docidentifier>
+  <uri type="xml">https://xml2rfc.tools.ietf.org/10.xml</uri>
+</bibitem>
+<bibitem id="ref12">
+  <formattedref format="application/x-isodoc+xml">CitationWorks. 2019. <em>How to cite a reference</em>.</formattedref>
+  <docidentifier type="metanorma">[Citn]</docidentifier>
+</bibitem>
+
+
+</references>
+</bibliography>
+    </iso-standard>
+    INPUT
+           #{XML_HDR}
+           <t anchor='_f06fd0d1-a203-4f3d-a515-0bdba0f8d83f'>
+               <relref target='ISO712' section=''/>
+               <relref target='ISBN' section=''/>
+               <relref target='ISSN' section=''/>
+               <relref target='ISO16634' section=''/>
+               <relref target='ref1' section=''/>
+               <relref target='ref10' section=''/>
+               <relref target='ref12' section=''/>
+             </t>
+           </abstract>
+         </front>
+         <middle/>
+         <back>
+           <references anchor='_normative_references'>
+             <name>Normative References</name>
+             <reference anchor='ISO712'>
+               <front>
+                 <title>Cereals or cereal products</title>
+                 <author>
+                   <organization ascii='International Organization for Standardization'>International Organization for Standardization</organization>
+                 </author>
+               </front>
+               <format target='http://www.example.com'/>
+               <refcontent>ISO 712</refcontent>
+             </reference>
+             <reference anchor='ISO16634'>
+               <front>
+                 <title>
+                   Cereals, pulses, milled cereal products, xxxx, oilseeds and animal
+                   feeding stuffs
+                 </title>
+                 <author>
+                   <organization ascii='International Supporters of Odium' abbrev='ISO1'>International Supporters of Odium</organization>
+                 </author>
+                 <keyword>keyword1</keyword>
+                 <keyword>keyword2</keyword>
+                 <abstract>
+                   <t>This is an abstract</t>
+                 </abstract>
+               </front>
+               <format target='http://www.example.com'/>
+               <format target='http://www.example.com/rdf' type='RDF'/>
+               <refcontent>ISO 16634:-- (all parts)</refcontent>
+<seriesInfo value='1234' name='DOI'/>
+             </reference>
+             <reference anchor='ISO20483'>
+               <front>
+                 <title>Cereals and pulses</title>
+                 <author fullname='&#xD6;laf N&#xFC;rk' asciiFullname='Olaf Nurk' surname='N&#xFC;rk' asciiSurname='Nurk'/>
+                 <author>
+                   <organization/>
+                 </author>
+                 <date year='2013'/>
+                 <abstract>
+                   <t>This is an abstract</t>
+                 </abstract>
+               </front>
+               <refcontent>ISO 20483:2013-2014</refcontent>
+             </reference>
+             <reference anchor='ref1'>
+               <front>
+                 <title>
+                   Standard No I.C.C 167.
+                   <em>
+                     Determination of the protein content in cereal and cereal products
+                     for food and animal feeding stuffs according to the Dumas
+                     combustion method
+                   </em>
+                    (see
+                   <eref target='http://www.icc.or.at'/>
+                   )
+                 </title>
+               </front>
+               <refcontent>ICC 167</refcontent>
+             </reference>
              <aside>
                <t>NOTE: This is an annotation of ISO 20483:2013-2014</t>
              </aside>
@@ -223,18 +536,18 @@ RSpec.describe IsoDoc::Ietf do
              <name>Bibliography</name>
              <reference anchor='ISBN'>
                <front>
-                 <title>1, Chemicals for analytical laboratory use</title>
+                 <title>Chemicals for analytical laboratory use</title>
                  <author>
-  <organization abbrev='ISBN'/>
-</author>
+                   <organization abbrev='ISBN'/>
+                 </author>
                </front>
              </reference>
              <reference anchor='ISSN'>
                <front>
-                 <title>2, Instruments for analytical laboratory use</title>
-               <author>
-  <organization abbrev='ISSN'/>
-</author>
+                 <title>Instruments for analytical laboratory use</title>
+                 <author>
+                   <organization abbrev='ISSN'/>
+                 </author>
                </front>
              </reference>
              <aside>
@@ -245,16 +558,17 @@ RSpec.describe IsoDoc::Ietf do
              </aside>
              <reference anchor='ISO3696'>
                <front>
-                 <title>ISO 3696, Water for analytical laboratory use</title>
-               <author>
-               <organization ascii='International Standards Organization' abbrev='ISO'>International Standards Organization</organization>
-</author>
+                 <title>Water for analytical laboratory use</title>
+                 <author>
+                   <organization ascii='International Standards Organization' abbrev='ISO'>International Standards Organization</organization>
+                 </author>
                </front>
+               <refcontent>ISO 3696</refcontent>
              </reference>
              <reference anchor='ref10'>
                <front>
                  <title>
-                   10, Standard No I.C.C 167.
+                   Standard No I.C.C 167.
                    <em>
                      Determination of the protein content in cereal and cereal products
                      for food and animal feeding stuffs according to the Dumas
@@ -270,7 +584,7 @@ RSpec.describe IsoDoc::Ietf do
              <reference anchor='ref12'>
                <front>
                  <title>
-                   Citn, CitationWorks. 2019.
+                   CitationWorks. 2019.
                    <em>How to cite a reference</em>
                    .
                  </title>
@@ -278,7 +592,8 @@ RSpec.describe IsoDoc::Ietf do
              </reference>
            </references>
          </back>
-       </rfc>
+         </rfc>
+
     OUTPUT
   end
 

--- a/spec/isodoc/section_spec.rb
+++ b/spec/isodoc/section_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
         <?rfc tocdepth="4"?>
         <?rfc symrefs="yes"?>
         <?rfc sortrefs="yes"?>
-        <rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3' prepTime='2000-01-01T05:00:00Z'>
+        <rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3'>
           <front>
             <seriesInfo value='' name='RFC' asciiName='RFC'/>
             <abstract> </abstract>

--- a/spec/isodoc/section_spec.rb
+++ b/spec/isodoc/section_spec.rb
@@ -151,6 +151,15 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
             </section>
           </middle>
           <back>
+            <references anchor='Q2'>
+              <name>Annex Bibliography</name>
+            </references>
+            <references anchor='R'>
+              <name>Normative References</name>
+            </references>
+            <references anchor='T'>
+              <name>Bibliography Subsection</name>
+            </references>
             <section anchor='P'>
               <name>Annex</name>
               <section anchor='Q'>
@@ -163,15 +172,6 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
                 </div>
               </section>
             </section>
-            <references anchor='Q2'>
-              <name>Annex Bibliography</name>
-            </references>
-            <references anchor='R'>
-              <name>Normative References</name>
-            </references>
-            <references anchor='T'>
-              <name>Bibliography Subsection</name>
-            </references>
           </back>
         </rfc>
 OUTPUT

--- a/spec/metanorma/processor_spec.rb
+++ b/spec/metanorma/processor_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metanorma::Ietf::Processor do
 
   it "registers output formats against metanorma" do
     expect(processor.output_formats.sort.to_s).to be_equivalent_to <<~"OUTPUT"
-    [[:html, "html"], [:rfc, "rfc.xml"], [:rxl, "rxl"], [:txt, "txt"], [:xml, "xml"]]
+    [[:html, "html"], [:pdf, "pdf"], [:rfc, "rfc.xml"], [:rxl, "rxl"], [:txt, "txt"], [:xml, "xml"]]
     OUTPUT
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -133,7 +133,7 @@ XML_HDR = <<~"HDR"
 <?rfc tocdepth="4"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-<rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3' prepTime='2000-01-01T05:00:00Z'>
+<rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3'>
   <front>
   <seriesInfo value='' name='RFC' asciiName='RFC'/>
     <abstract>
@@ -147,7 +147,7 @@ RFC_HDR = <<~"HDR"
 <?rfc tocdepth="4"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
-       <rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3' prepTime='2000-01-01T05:00:00Z'>
+       <rfc xmlns:xi='http://www.w3.org/2001/XInclude' category='std' submissionType='IETF' version='3'>
          <front>
   <seriesInfo value='' name='RFC' asciiName='RFC'/>
 </front>


### PR DESCRIPTION
Fixes below:
- Do not add cross-reference content in xref (IETF will autopopulate it).
- Process all URIs in reference, including "src" URI, as formats, rather than making the first URI be the reference target.
- Process DOI and IETF docidentifiers in references.
- Do not prepend the identifier if it is IETF or DOI. Move it instead to refcontent.
- Annex goes after the bibliography.
- Remove prepTime (optional attribute).
- Always keep the xml references.
- Add <t> in abstract of references.
- Output pdf files.

We will need to update specs to accommodate these fixes.