### PR TITLE
Some cleanup of IETF processor for file formats

### DIFF
--- a/lib/isodoc/ietf/rfc_convert.rb
+++ b/lib/isodoc/ietf/rfc_convert.rb
@@ -56,5 +56,10 @@ module IsoDoc::Ietf
       File.open("#{filename}.rfc.xml", "w:UTF-8") { |f| f.write(result) }
       @files_to_delete.each { |f| FileUtils.rm_rf f }
     end
+
+    def init_file(filename, debug)
+      filename = filename.sub(/\.rfc\.xml$/, ".rfc")
+      super
+    end
   end
 end


### PR DESCRIPTION

How `metanorma -t ietf a.adoc` should work:

1. generate MN xml at a.xml
2. generate RFC XML at a.rfc.xml
