### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/ietf/processor.rb
+++ b/lib/metanorma/ietf/processor.rb
@@ -26,11 +26,6 @@ module Metanorma
         "Metanorma::Ietf #{::Metanorma::Ietf::VERSION}"
       end
 
-      def input_to_isodoc(file, filename)
-        # This is XML RFC v3 output in text
-        Metanorma::Input::Asciidoc.new.process(file, filename, @asciidoctor_backend)
-      end
-
       def extract_options(isodocxml)
         {}
       end


### PR DESCRIPTION
move the Metanorma::Ietf::Processor#input_to_isodoc method to Metanorma::Processor
metanorma/metanorma-cli#134