### PR TITLE
chore: migrate from xml2rfc-rake to generic-rake workflow

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   rake:
-    uses: metanorma/ci/.github/workflows/xml2rfc-rake.yml@main
+    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
+    with:
+      setup-tools: xml2rfc
+      submodules: false
+      choco-cache: true
     secrets:
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}


### PR DESCRIPTION
Migrate to the consolidated generic-rake.yml workflow with setup-tools: xml2rfc. Part of metanorma/ci#259.