### PR TITLE
Emit format-gated passthrough for comma-separated formats lists

### DIFF
--- a/lib/isodoc/ietf/blocks.rb
+++ b/lib/isodoc/ietf/blocks.rb
@@ -1,6 +1,19 @@
 module IsoDoc
   module Ietf
     class RfcConvert < ::IsoDoc::Convert
+      # The presentation layer normalises comma-separated passthrough
+      # formats to space-separated (PresentationXMLConvert#passthrough1);
+      # RfcConvert runs on semantic XML and skips that layer, so
+      # formats="rfc,html" never matched the base class's whitespace
+      # split and the content was silently dropped (#275). Split on
+      # commas as well.
+      def passthrough_parse(node, out)
+        node["formats"] &&
+          !node["formats"].split(/[,[:space:]]+/).include?(@format.to_s) and
+          return
+        out.passthrough node.text
+      end
+
       def para_attrs(node)
         { keepWithNext: node["keep-with-next"],
           keepWithPrevious: node["keep-with-previous"],

--- a/spec/isodoc/inline_spec.rb
+++ b/spec/isodoc/inline_spec.rb
@@ -633,6 +633,34 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
       OUTPUT
   end
 
+  it "processes format-gated passthrough with comma-separated formats" do
+    FileUtils.rm_f "test.rfc.xml"
+    IsoDoc::Ietf::RfcConvert.new({}).convert("test", <<~"INPUT", false)
+      #{BLANK_HDR}
+      <preface><foreword>
+      <p>
+      <passthrough formats="rfc,html">&lt;abc&gt;X&lt;/abc&gt;</passthrough>
+      </p>
+      </preface>
+      </iso-standard>
+    INPUT
+    expect(File.read("test.rfc.xml")).to include "<abc>X</abc>"
+  end
+
+  it "drops format-gated passthrough for non-matching formats" do
+    FileUtils.rm_f "test.rfc.xml"
+    IsoDoc::Ietf::RfcConvert.new({}).convert("test", <<~"INPUT", false)
+      #{BLANK_HDR}
+      <preface><foreword>
+      <p>
+      <passthrough formats="html,doc">&lt;abc&gt;X&lt;/abc&gt;</passthrough>
+      </p>
+      </preface>
+      </iso-standard>
+    INPUT
+    expect(File.read("test.rfc.xml")).not_to include "<abc>"
+  end
+
   it "processes concept markup" do
     input = <<~INPUT
              <iso-standard xmlns="http://riboseinc.com/isoxml">


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-ietf/issues/275

Split passthrough formats on commas as well as whitespace in
RfcConvert, restoring format-gated passthrough content
([format="rfc,html"]) to RFC XML output. Specs for the matching and
non-matching cases. Narrative on the ticket.

🤖
