### PR TITLE
render generator errormsg in concept in boldface

### DIFF
--- a/lib/isodoc/ietf/terms.rb
+++ b/lib/isodoc/ietf/terms.rb
@@ -86,6 +86,10 @@ module IsoDoc
       def termdocsource_parse(_node, _out); end
 
       def concept_parse(node, out)
+        # generator-emitted term-resolution failure reports
+        # (metanorma-model-iso#144) render in boldface
+        err = node.at(ns("./errormsg")) and
+          return out.strong { |s| err.children.each { |n| parse(n, s) } }
         ref = node.at(ns("./xref | ./eref | ./termref"))
         render = node.at(ns("./renderterm"))
         !ref && !render and return node.children.each { |n| parse(n, out) }

--- a/spec/isodoc/inline_spec.rb
+++ b/spec/isodoc/inline_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
               <renderterm>word</renderterm>
               <termref base='IEV' target='135-13-13'>The IEV database</termref>
             </concept></li>
-            <li><concept><strong>term <tt>participant's</tt> not resolved via ID <tt>participant__x2019_s</tt></strong></concept></li>
+            <li><concept><errormsg>term <tt>participant's</tt> not resolved via ID <tt>participant__x2019_s</tt></errormsg></concept></li>
             </ul>
           </p>
           </foreword></preface>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/pull/1229

Downstream of metanorma-model-iso#144: RfcConvert consumes semantic XML (no isodoc presentation pass), so `concept_parse` renders `errormsg` as `strong` directly; the unrecognised element previously fell through to an escaped text dump in a nested `<t>`. Existing unresolved-concept spec input converted, output expectation unchanged.

🤖
