### PR TITLE
Robustness fixes from the #257 heritage battery

### DIFF
--- a/lib/isodoc/ietf/blocks.rb
+++ b/lib/isodoc/ietf/blocks.rb
@@ -90,7 +90,10 @@ module IsoDoc
       def pre_parse(node, out)
         out.artwork **attr_code(anchor: node["id"], align: node["align"],
                                 alt: node["alt"], type: "ascii-art") do |s|
-          s.cdata node.text.sub(/^\n/, "").gsub(/\t/, "    ")
+          # \A, not ^: ^ anchors at every line start, so /^\n/ deleted
+          # the first BLANK LINE inside the artwork instead of a
+          # leading newline (#286)
+          s.cdata node.text.sub(/\A\n/, "").gsub(/\t/, "    ")
         end
       end
 

--- a/lib/isodoc/ietf/cleanup_blocks.rb
+++ b/lib/isodoc/ietf/cleanup_blocks.rb
@@ -146,6 +146,11 @@ module IsoDoc
 
       def sourcecode_xref(node)
         ret = @xrefs.anchor(node["target"], :xref, false)&.gsub(%r{<[^>]+>}, "")
+        # an unresolved target yields nil: degrade to the raw target
+        # text instead of crashing Node#replace (#278; trigger: xref
+        # inside a literal block in an abstract, whose anchors the
+        # xref table does not know)
+        ret ||= node["target"].to_s
         s = node["section"] and ret += ", Section #{s}"
         node.replace(ret)
       end

--- a/lib/isodoc/ietf/front.rb
+++ b/lib/isodoc/ietf/front.rb
@@ -228,16 +228,19 @@ module IsoDoc
       end
 
       def note(isoxml, front)
-        a = isoxml.at(ns("//preface/abstract/note | //preface/foreword/note")) or
-          return
-        front.note **attr_code(removeInRFC: a["removeInRFC"]) do |n|
-          title = a.at(ns("./name")) and n.name do |t|
-            title.children.each { |tt| parse(tt, t) }
+        # every abstract note, not just the first: the .at singleton
+        # silently deleted any further notes (#285)
+        isoxml.xpath(ns("//preface/abstract/note | //preface/foreword/note"))
+          .each do |a|
+          front.note **attr_code(removeInRFC: a["removeInRFC"]) do |n|
+            title = a.at(ns("./name")) and n.name do |t|
+              title.children.each { |tt| parse(tt, t) }
+            end
+            a.children.reject { |c1| c1.name == "name" }.each do |c1|
+              parse(c1, n)
+            end
+            a.remove
           end
-          a.children.reject { |c1| c1.name == "name" }.each do |c1|
-            parse(c1, n)
-          end
-          a.remove
         end
       end
 

--- a/lib/isodoc/ietf/lists.rb
+++ b/lib/isodoc/ietf/lists.rb
@@ -54,7 +54,10 @@ module IsoDoc
       end
 
       def dt_parse(dterm, term)
-        if dterm.elements.empty? then term << dterm.text
+        # text, not <<: the raw-fragment insert parses the string as
+        # markup, so a bare "&" (or "<") in the term is invalid there
+        # and libxml2 drops it silently (#287; same class as #267)
+        if dterm.elements.empty? then term.text dterm.text
         else dterm.children.each { |n| parse(n, term) }
         end
       end

--- a/lib/isodoc/ietf/references.rb
+++ b/lib/isodoc/ietf/references.rb
@@ -94,7 +94,9 @@ module IsoDoc
           ref.front do |front|
             front.title do |t|
               if f then children_parse(f, t)
-              else t << did.text
+              # text, not <<: raw-fragment insert silently drops a
+              # bare "&" in the identifier (#287 sibling)
+              else t.text did.text
               end
             end
           end

--- a/lib/isodoc/ietf/references.rb
+++ b/lib/isodoc/ietf/references.rb
@@ -85,7 +85,12 @@ module IsoDoc
         # unify with the shared bibrender path when refactoring the reference
         # pipeline.
         did = bib1.at(ns("./docidentifier"))
-        if !bib1.at(ns("./title")) && (f || did)
+        # A formattedref takes this path even when a title is also
+        # present: relaton-render honours the formattedref by returning
+        # it as BARE TEXT, which then lands as loose text inside
+        # <reference> -- invalid RFC XML (#279; trigger: relaton BCP
+        # collection items, e.g. citing "BCP 14").
+        if f || (!bib1.at(ns("./title")) && did)
           ref.front do |front|
             front.title do |t|
               if f then children_parse(f, t)

--- a/lib/isodoc/ietf/validation.rb
+++ b/lib/isodoc/ietf/validation.rb
@@ -188,11 +188,21 @@ module IsoDoc
         ret
       end
 
+      # RFC 7991 s2.45.5: the legal ipr values. The old
+      # /trust200902$/ test matched only the bare lowercase value --
+      # every capital-T variant (pre5378Trust200902,
+      # noModificationTrust200902, ...) and the 200811 family were
+      # rejected as unknown (#280).
+      IPR_VALUES = %w(trust200902 noModificationTrust200902
+                      noDerivativesTrust200902 pre5378Trust200902
+                      trust200811 noModificationTrust200811
+                      noDerivativesTrust200811 none).freeze
+
       # 5.4.2.3.  "Copyright Notice" Insertion
       def ipr_check(xml)
         xml.root["ipr"] or
           return ["Missing ipr attribute on <rfc> element (:ipr:)"]
-        /trust200902$/.match(xml.root["ipr"]) or
+        IPR_VALUES.include?(xml.root["ipr"]) or
           return ["Unknown ipr attribute on <rfc> element (:ipr:): " \
                   "#{xml.root['ipr']}"]
         []

--- a/lib/relaton/render/parse.rb
+++ b/lib/relaton/render/parse.rb
@@ -14,11 +14,18 @@ module Relaton
                     abstract: abstract(doc))
         end
 
-        def home_standard(_doc, pubs)
+        def home_standard(doc, pubs)
           pubs&.any? do |r|
             ["Internet Engineering Task Force", "IETF", "RFC Publisher"]
               .include?(r[:nonpersonal])
-          end
+          end ||
+            # an Internet-Draft is an IETF-stream document even though
+            # its relaton record carries no publisher contributor;
+            # without this, draft references fell to the refcontent
+            # branch and never got the seriesInfo that makes xml2rfc
+            # render "Work in Progress, Internet-Draft, ..." (#283)
+            Array(doc.docidentifier)
+              .any? { |i| i.type == "Internet-Draft" }
         end
 
         # allow publisher for standards
@@ -107,9 +114,9 @@ module Relaton
         def creatornames1(doc)
           return [] if doc.nil?
 
-          add1 = pick_contributor(doc, "author") || []
-          add2 = pick_contributor(doc, "editor") || []
-          cr = add1 + add2
+          cr = Array(doc.contributor).select do |c|
+            Array(c.role).any? { |r| %w(author editor).include?(r.type) }
+          end
           cr.empty? or return cr
           super
         end
@@ -119,8 +126,26 @@ module Relaton
           bcp = Array(doc.series).detect do |s|
             %w(BCP STD).include?(Array(s.title).first&.content)
           end
-          bcp and ret.unshift("BCP\u00A0#{bcp.number}")
-          ret.reject { |x| /(rfc-anchor|Internet-Draft)/.match?(x) }
+          # label the sub-series by its own title: the unconditional
+          # "BCP" prefix rendered every STD-series RFC as BCP
+          # (STD 63 -> "BCP 63", #282)
+          bcp and ret.unshift(
+            "#{Array(bcp.title).first&.content}\u00A0#{bcp.number}",
+          )
+          # Internet-Draft identifiers stay: rejecting them (as the
+          # rfc-anchor internals rightly are) left draft references
+          # with NO seriesInfo, so xml2rfc never rendered "Work in
+          # Progress, Internet-Draft, draft-name" (#283). Only the
+          # unversioned duplicate of the primary id is dropped.
+          primary = ret.grep(/Internet-Draft/).max_by(&:length)
+          ret.reject do |x|
+            /rfc-anchor/.match?(x) ||
+              (/Internet-Draft/.match?(x) && x != primary) ||
+              # the I-D. anchor form duplicates the real draft name
+              # with an unprefixed, unversioned value — drop it when
+              # a proper Internet-Draft identifier is present
+              (primary && /I-D\./.match?(x))
+          end
             .map { |x| x.gsub(/<\/?esc>/, "").tr(" ", "\u00A0") }
         end
 

--- a/lib/relaton/render/parse.rb
+++ b/lib/relaton/render/parse.rb
@@ -110,7 +110,11 @@ module Relaton
           datepick(ret)
         end
 
-        # return authors and editors together
+        # return authors and editors together, in DOCUMENT order:
+        # concatenating all authors then all editors re-ordered mixed
+        # lists — RFC 5234 (data order Crocker (ed.), Overell)
+        # rendered as "Overell, P. and D. Crocker", and organisational
+        # authors were hoisted over persons (#284)
         def creatornames1(doc)
           return [] if doc.nil?
 

--- a/spec/isodoc/cleanup_spec.rb
+++ b/spec/isodoc/cleanup_spec.rb
@@ -1271,4 +1271,32 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
       .cleanup(Nokogiri::XML(input)).to_s)
       .to be_xml_equivalent_to output
   end
+  it "degrades an unresolvable xref in an abstract instead of " \
+     "crashing (#278)" do
+    # an empty xref with a target the xref table does not know made
+    # sourcecode_xref replace with nil (ArgumentError in
+    # abstract_cleanup); trigger observed on a literal block inside
+    # an abstract (MIB Doctor template)
+    FileUtils.rm_f "test.rfc.xml"
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <bibdata>
+      <title language="en" format="text/plain" type="main">Test</title>
+      <docidentifier>draft-test-abstract-xref-01</docidentifier><docnumber>10</docnumber>
+      <contributor><role type="author"/><person>
+      <name><completename>Arthur son of Uther Pendragon</completename></name></person></contributor>
+      <ext><ipr>trust200902</ipr></ext>
+      </bibdata>
+      <preface><abstract id="_abs">
+      <p id="_p1">See <xref target="TEMPLATE-TODO"/>.</p>
+      </abstract></preface>
+      <sections><clause id="A"><title>A-title</title><p>A</p></clause></sections>
+      </iso-standard>
+    INPUT
+    expect do
+      IsoDoc::Ietf::RfcConvert.new({}).convert("test", input, false)
+    end.not_to raise_error
+    out = File.read("test.rfc.xml")
+    expect(out).to include "TEMPLATE-TODO"
+  end
 end

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe IsoDoc::Ietf do
                       <author fullname="Bernard Aboba"/>
                       <date month="October" year="2003"/>
                    </front>
-                   <seriesInfo value="aboba-context-802" name="Internet-Draft"/>
+                   <seriesInfo value="draft-aboba-context-802-00" name="Internet-Draft"/>
                 </reference>
              </references>
           </back>
@@ -999,7 +999,7 @@ RSpec.describe IsoDoc::Ietf do
                             </abstract>
                          </front>
                          <seriesInfo value="10.17487/RFC5730" name="DOI"/>
-                         <refcontent>BCP 69, RFC 5730</refcontent>
+                         <refcontent>STD 69, RFC 5730</refcontent>
                       </reference>
                       <reference target="https://www.rfc-editor.org/info/rfc5731" anchor="_">
                          <stream>IETF</stream>
@@ -1017,7 +1017,7 @@ RSpec.describe IsoDoc::Ietf do
                             </abstract>
                          </front>
                          <seriesInfo value="10.17487/RFC5731" name="DOI"/>
-                         <refcontent>BCP 69, RFC 5731</refcontent>
+                         <refcontent>STD 69, RFC 5731</refcontent>
                       </reference>
                       <reference target="https://www.rfc-editor.org/info/rfc5732" anchor="_">
                          <stream>IETF</stream>
@@ -1034,7 +1034,7 @@ RSpec.describe IsoDoc::Ietf do
                             </abstract>
                          </front>
                          <seriesInfo value="10.17487/RFC5732" name="DOI"/>
-                         <refcontent>BCP 69, RFC 5732</refcontent>
+                         <refcontent>STD 69, RFC 5732</refcontent>
                       </reference>
                       <reference target="https://www.rfc-editor.org/info/rfc5733" anchor="_">
                          <stream>IETF</stream>
@@ -1052,7 +1052,7 @@ RSpec.describe IsoDoc::Ietf do
                             </abstract>
                          </front>
                          <seriesInfo value="10.17487/RFC5733" name="DOI"/>
-                         <refcontent>BCP 69, RFC 5733</refcontent>
+                         <refcontent>STD 69, RFC 5733</refcontent>
                       </reference>
                       <reference target="https://www.rfc-editor.org/info/rfc5734" anchor="_">
                          <stream>IETF</stream>
@@ -1070,7 +1070,7 @@ RSpec.describe IsoDoc::Ietf do
                             </abstract>
                          </front>
                          <seriesInfo value="10.17487/RFC5734" name="DOI"/>
-                         <refcontent>BCP 69, RFC 5734</refcontent>
+                         <refcontent>STD 69, RFC 5734</refcontent>
                       </reference>
                    </referencegroup>
                 </references>

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -1125,6 +1125,44 @@ RSpec.describe IsoDoc::Ietf do
     OUTPUT
   end
 
+  it "renders a formattedref bibitem that also carries a title " \
+     "as front/title, not loose text (#279)" do
+    # relaton BCP collection items (citing "BCP 14") carry BOTH a
+    # formattedref and a title; the render path for titled bibitems
+    # hands them to relaton-render, which honours the formattedref by
+    # returning bare text -- emitted as loose text inside <reference>,
+    # which the RFC XML grammar rejects
+    FileUtils.rm_f "test.rfc.xml"
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <bibdata>
+      <title language="en" format="text/plain" type="main">Test</title>
+      <docidentifier>draft-test-bcp14-01</docidentifier><docnumber>10</docnumber>
+      <contributor><role type="author"/><person>
+      <name><completename>Arthur son of Uther Pendragon</completename></name></person></contributor>
+      <ext><ipr>trust200902</ipr></ext>
+      </bibdata>
+      <sections><clause id="A"><title>A-title</title><p>A</p></clause></sections>
+      <bibliography><references id="_normative" obligation="informative" normative="true">
+      <title>Normative References</title>
+      <bibitem anchor="BCP14" id="_bcp14001" type="standard">
+        <formattedref>BCP14</formattedref>
+        <title language="en" script="Latn">Best Current Practice 14</title>
+        <uri type="src">https://www.rfc-editor.org/info/bcp14</uri>
+        <docidentifier type="IETF" primary="true">BCP 14</docidentifier>
+      </bibitem>
+      </references></bibliography>
+      </iso-standard>
+    INPUT
+    IsoDoc::Ietf::RfcConvert.new({}).convert("test", input, false)
+    out = Nokogiri::XML(File.read("test.rfc.xml"))
+    ref = out.at("//reference[@anchor='BCP14']")
+    expect(ref).not_to be_nil
+    expect(ref.at("./front/title")&.text).to eq "BCP14"
+    loose = ref.children.select { |c| c.text? && !c.text.strip.empty? }
+    expect(loose).to be_empty
+  end
+
   it "normalises reference stream to the xml2rfc enumeration (#270)" do
     # relaton stream values arrive in arbitrary case (INDEPENDENT), but
     # <stream> admits only IAB/IETF/IRTF/independent; unknown streams

--- a/spec/isodoc/validate_spec.rb
+++ b/spec/isodoc/validate_spec.rb
@@ -816,4 +816,42 @@ RSpec.describe IsoDoc::Ietf::RfcConvert do
       .to output(%r{RFC XML: Unknown ipr attribute on <rfc> element \(:ipr:\): trust2009021})
       .to_stderr
   end
+
+  it "accepts every RFC 7991 ipr value" do
+    template = <<~INPUT
+          <rfc xmlns:xi="http://www.w3.org/2001/XInclude" docName="draft-camelot-holy-grenade-01" ipr="IPRVALUE" category="info" sortRefs="true" tocInclude="true" submissionType="independent" xml:lang="en" version="3" >
+        <front>
+          <title abbrev="Hand Grenade of Antioch">The Holy Hand Grenade of Antioch</title>
+          <seriesInfo value="draft-camelot-holy-grenade-01" status="Informational" stream="independent" name="Internet-Draft" asciiName="Internet-Draft"></seriesInfo>
+          <author fullname="Arthur son of Uther Pendragon">
+            <address>
+              <postal></postal>
+              <email>arthur.pendragon@ribose.com</email>
+            </address>
+          </author>
+          <abstract anchor="_absttacr">
+      <t anchor="_2cf15089-1c6a-4156-a904-94376faa6cd1">Abc
+      Def</t>
+      </abstract>
+        </front>
+        <middle>
+        <section anchor="A" numbered="true" toc="exclude">
+        <name>Clause</name>
+        </section>
+        </middle>
+        </rfc>
+    INPUT
+    # the old /trust200902$/ test rejected every capital-T variant
+    # and the 200811 family (#280)
+    %w(pre5378Trust200902 noModificationTrust200902
+       noDerivativesTrust200902 trust200811 noModificationTrust200811
+       noDerivativesTrust200811 none).each do |ipr|
+      expect do
+        IsoDoc::Ietf::RfcConvert.new({})
+          .postprocess(template.sub("IPRVALUE", ipr), "test.rfc.xml", nil)
+      end
+        .not_to output(%r{RFC XML: Unknown ipr attribute})
+        .to_stderr
+    end
+  end
 end

--- a/spec/isodoc/ws5_regressions_spec.rb
+++ b/spec/isodoc/ws5_regressions_spec.rb
@@ -64,4 +64,51 @@ RSpec.describe IsoDoc::Ietf do
     dt = Nokogiri::XML(out).at("//dt")
     expect(dt.text).to eq "Person & email address: "
   end
+
+  STD_BIBITEM = <<~BIB.freeze
+    <bibliography><references id="_n" normative="true"><title>Normative References</title>
+    <bibitem id="RFC3629" anchor="RFC3629" type="standard">
+    <title type="main">UTF-8, a transformation format of ISO 10646</title>
+    <uri type="src">https://www.rfc-editor.org/info/rfc3629</uri>
+    <docidentifier type="IETF" primary="true">RFC 3629</docidentifier>
+    <docidentifier type="DOI">10.17487/RFC3629</docidentifier>
+    <date type="published"><on>2003-11</on></date>
+    <contributor><role type="author"/><person><name><completename>F. Yergeau</completename></name></person></contributor>
+    <contributor><role type="publisher"/><organization><name>RFC Publisher</name></organization></contributor>
+    <series><title>STD</title><number>63</number></series>
+    <series><title>RFC</title><number>3629</number></series>
+    </bibitem>
+    </references></bibliography>
+  BIB
+
+  it "labels an STD sub-series as STD, not BCP (#282)" do
+    out = ws5_convert(<<~BODY, bibliography: STD_BIBITEM)
+      <sections><clause id="A"><title>C</title><p id="P">See <eref bibitemid="RFC3629"/>.</p></clause></sections>
+    BODY
+    ref = Nokogiri::XML(out).at("//reference[@anchor='RFC3629']")
+    expect(ref.at(".//seriesInfo[@name='STD']/@value")&.text).to eq "63"
+    expect(ref.at(".//seriesInfo[@name='BCP']")).to be_nil
+  end
+
+  it "emits seriesInfo for Internet-Draft references (#283)" do
+    out = ws5_convert(<<~BODY, bibliography: <<~BIB)
+      <sections><clause id="A"><title>C</title><p id="P">See <eref bibitemid="ID1"/>.</p></clause></sections>
+    BODY
+      <bibliography><references id="_n" normative="true"><title>Normative References</title>
+      <bibitem id="ID1" anchor="ID1" type="standard">
+      <title type="main">Origin Cookies</title>
+      <uri type="src">https://datatracker.ietf.org/doc/html/draft-abarth-cake-01</uri>
+      <docidentifier type="Internet-Draft">draft-abarth-cake</docidentifier>
+      <docidentifier type="Internet-Draft" primary="true">draft-abarth-cake-01</docidentifier>
+      <date type="published"><on>2011-03-05</on></date>
+      <contributor><role type="author"/><person><name><completename>A. Barth</completename></name></person></contributor>
+      <series type="main"><title>Internet-Draft</title><number>draft-abarth-cake-01</number></series>
+      </bibitem>
+      </references></bibliography>
+    BIB
+    ref = Nokogiri::XML(out).at("//reference[@anchor='ID1']")
+    si = ref.at(".//seriesInfo[@name='Internet-Draft']")
+    expect(si).not_to be_nil
+    expect(si["value"]).to eq "draft-abarth-cake-01"
+  end
 end

--- a/spec/isodoc/ws5_regressions_spec.rb
+++ b/spec/isodoc/ws5_regressions_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+# Regressions surfaced by the metanorma-ietf#233 QA heritage battery
+# (issues #282-#287): each example is the minimal repro from the
+# corresponding ticket.
+RSpec.describe IsoDoc::Ietf do
+  HDR = <<~HDR.freeze
+    <bibdata>
+    <title language="en" format="text/plain" type="main">Test</title>
+    <docidentifier>draft-test-00</docidentifier><docnumber>10</docnumber>
+    <contributor><role type="author"/><person>
+    <name><completename>Arthur son of Uther Pendragon</completename></name></person></contributor>
+    <ext><ipr>trust200902</ipr></ext>
+    </bibdata>
+  HDR
+
+  def ws5_convert(body, bibliography: "")
+    FileUtils.rm_f "test.rfc.xml"
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      #{HDR}
+      #{body}
+      #{bibliography}
+      </iso-standard>
+    INPUT
+    IsoDoc::Ietf::RfcConvert.new({}).convert("test", input, false)
+    File.read("test.rfc.xml")
+  end
+
+  it "renders every abstract note, not just the first (#285)" do
+    out = ws5_convert(<<~BODY)
+      <preface><abstract id="_abs">
+      <p id="_p1">Abstract text.</p>
+      <note id="_n1"><p id="_np1">First note.</p></note>
+      <note id="_n2"><p id="_np2">Second note.</p></note>
+      </abstract></preface>
+      <sections><clause id="A"><title>C</title><p id="P">Body.</p></clause></sections>
+    BODY
+    notes = Nokogiri::XML(out).xpath("//front/note")
+    expect(notes.size).to eq 2
+    expect(notes[1].text).to include "Second note."
+  end
+end

--- a/spec/isodoc/ws5_regressions_spec.rb
+++ b/spec/isodoc/ws5_regressions_spec.rb
@@ -53,4 +53,15 @@ RSpec.describe IsoDoc::Ietf do
     # the blank line inside the artwork is the point
     expect(out).to include "LINE ONE\n\nLINE TWO"
   end
+
+  it "keeps a literal ampersand in a definition-list term (#287)" do
+    out = ws5_convert(<<~BODY)
+      <sections><clause id="A"><title>C</title>
+      <dl id="D1"><dt>Person &amp; email address: </dt>
+      <dd id="DD1"><p id="P2">list</p></dd></dl>
+      </clause></sections>
+    BODY
+    dt = Nokogiri::XML(out).at("//dt")
+    expect(dt.text).to eq "Person & email address: "
+  end
 end

--- a/spec/isodoc/ws5_regressions_spec.rb
+++ b/spec/isodoc/ws5_regressions_spec.rb
@@ -40,4 +40,17 @@ RSpec.describe IsoDoc::Ietf do
     expect(notes.size).to eq 2
     expect(notes[1].text).to include "Second note."
   end
+
+  it "keeps a blank line inside a literal block's artwork (#286)" do
+    out = ws5_convert(<<~BODY)
+      <sections><clause id="A"><title>C</title>
+      <figure id="F"><pre>    LINE ONE
+
+    LINE TWO</pre></figure>
+      </clause></sections>
+    BODY
+    # the squiggly heredoc strips the lines' common indent;
+    # the blank line inside the artwork is the point
+    expect(out).to include "LINE ONE\n\nLINE TWO"
+  end
 end

--- a/spec/isodoc/ws5_regressions_spec.rb
+++ b/spec/isodoc/ws5_regressions_spec.rb
@@ -111,4 +111,27 @@ RSpec.describe IsoDoc::Ietf do
     expect(si).not_to be_nil
     expect(si["value"]).to eq "draft-abarth-cake-01"
   end
+
+  it "keeps reference authors in document order (#284)" do
+    out = ws5_convert(<<~BODY, bibliography: <<~BIB)
+      <sections><clause id="A"><title>C</title><p id="P">See <eref bibitemid="RFC5234"/>.</p></clause></sections>
+    BODY
+      <bibliography><references id="_n" normative="true"><title>Normative References</title>
+      <bibitem id="RFC5234" anchor="RFC5234" type="standard">
+      <title type="main">Augmented BNF for Syntax Specifications: ABNF</title>
+      <uri type="src">https://www.rfc-editor.org/info/rfc5234</uri>
+      <docidentifier type="IETF" primary="true">RFC 5234</docidentifier>
+      <date type="published"><on>2008-01</on></date>
+      <contributor><role type="editor"/><person><name><completename>D. Crocker</completename></name></person></contributor>
+      <contributor><role type="author"/><person><name><completename>P. Overell</completename></name></person></contributor>
+      <contributor><role type="publisher"/><organization><name>RFC Publisher</name></organization></contributor>
+      <series><title>STD</title><number>68</number></series>
+      </bibitem>
+      </references></bibliography>
+    BIB
+    ref = Nokogiri::XML(out).at("//reference[@anchor='RFC5234']")
+    authors = ref.xpath(".//author").map { |a| a["fullname"] || a["surname"] }
+    expect(authors.first).to include "Crocker"
+    expect(authors[1]).to include "Overell"
+  end
 end


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-ietf/issues/278
Closes https://github.com/metanorma/metanorma-ietf/issues/279
Closes https://github.com/metanorma/metanorma-ietf/issues/280
Closes https://github.com/metanorma/metanorma-ietf/issues/282
Closes https://github.com/metanorma/metanorma-ietf/issues/283
Closes https://github.com/metanorma/metanorma-ietf/issues/284
Closes https://github.com/metanorma/metanorma-ietf/issues/285
Closes https://github.com/metanorma/metanorma-ietf/issues/286
Closes https://github.com/metanorma/metanorma-ietf/issues/287

Nine robustness and rendering fixes surfaced by the #257 QA heritage
battery (details in the issues, one commit each): unresolvable
abstract xrefs no longer crash the conversion; formattedref-carrying
bibitems (relaton BCP collection items — the sharpened #279
diagnosis, not the free-text manual bibitems named in the issue)
render as front/title instead of invalid loose text; the ipr
validator accepts the full RFC 7991 value set (the old
/trust200902$/ test rejected every capital-T variant and the 200811
family, not just pre5378Trust200902); STD sub-series are labelled
STD, not BCP; Internet-Draft references regain their seriesInfo
("Work in Progress, Internet-Draft, draft-name"); reference authors
keep document order; every abstract note renders, not just the
first; blank lines inside literal-block artwork survive; literal
ampersands in definition-list terms survive.

🤖
