### PR TITLE
Emit ext/pi in its modelled slot; stamp ids on pre in literal blocks

### DIFF
--- a/lib/metanorma/ietf/blocks.rb
+++ b/lib/metanorma/ietf/blocks.rb
@@ -68,8 +68,9 @@ module Metanorma
         noko do |xml|
           xml.figure **literal_attrs(node) do |f|
             block_title(node, f)
-            f.pre node.lines.join("\n"),
-                  **attr_code(align: node.attr("align"), alt: node.attr("alt"))
+            pre_attrs = id_attr(node).tap { |h| h.delete(:anchor) }
+              .merge(align: node.attr("align"), alt: node.attr("alt"))
+            f.pre node.lines.join("\n"), **attr_code(pre_attrs)
           end
         end
       end

--- a/lib/metanorma/ietf/front.rb
+++ b/lib/metanorma/ietf/front.rb
@@ -65,6 +65,7 @@ module Metanorma
         end
         add_noko_elem(xml, "ipr", node.attr("ipr") || "trust200902")
         # xml.ipr (node.attr("ipr") || "trust200902")
+        xml.pi { |pi| set_pi(node, pi) }
         x = node.attr("consensus") and xml.consensus (x != "false")
         x = node.attr("index-include") and xml.indexInclude (x != "false")
         add_noko_elem(xml, "iprExtract", node.attr("ipr-extract"))
@@ -75,7 +76,6 @@ module Metanorma
         add_noko_elem(xml, "tocDepth", node.attr("toc-depth"))
         # x = node.attr("toc-depth") and xml.tocDepth x
         x = node.attr("show-on-front-page") and xml.showOnFrontPage (x != "false")
-        xml.pi { |pi| set_pi(node, pi) }
       end
 
       def set_pi(node, pi)

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -416,14 +416,6 @@ RSpec.describe Metanorma::Ietf do
              <area>B</area>
              <area>C</area>
              <ipr>noModificationTrust200902,pre5378Trust200902</ipr>
-             <consensus>false</consensus>
-             <indexInclude>false</indexInclude>
-             <iprExtract>Section 3</iprExtract>
-             <sortRefs>false</sortRefs>
-             <symRefs>false</symRefs>
-             <tocInclude>false</tocInclude>
-             <tocDepth>9</tocDepth>
-             <showOnFrontPage>false</showOnFrontPage>
              <pi>
                <artworkdelimiter>1</artworkdelimiter>
                <artworklines>2</artworklines>
@@ -461,6 +453,14 @@ RSpec.describe Metanorma::Ietf do
                <symrefs>false</symrefs>
                <sortrefs>false</sortrefs>
              </pi>
+             <consensus>false</consensus>
+             <indexInclude>false</indexInclude>
+             <iprExtract>Section 3</iprExtract>
+             <sortRefs>false</sortRefs>
+             <symRefs>false</symRefs>
+             <tocInclude>false</tocInclude>
+             <tocDepth>9</tocDepth>
+             <showOnFrontPage>false</showOnFrontPage>
            </ext>
          </bibdata>
          <metanorma-extension>

--- a/spec/metanorma/blocks_spec.rb
+++ b/spec/metanorma/blocks_spec.rb
@@ -252,7 +252,28 @@ RSpec.describe Metanorma::Ietf do
       #{BLANK_HDR}
        <sections>
            <figure id="_" anchor="lit">
-        <pre align='left' alt='hello'>&lt;LITERAL&gt;</pre>
+        <pre id="_" align='left' alt='hello'>&lt;LITERAL&gt;</pre>
+        </figure>
+       </sections>
+       </metanorma>
+
+    OUTPUT
+    expect(strip_guid(Asciidoctor.convert(input, *OPTIONS)))
+      .to be_xml_equivalent_to output
+  end
+
+  it "stamps an id on the pre of an unanchored literal" do
+    input = <<~INPUT
+      #{ASCIIDOC_BLANK_HDR}
+      ....
+      <LITERAL>
+      ....
+    INPUT
+    output = <<~OUTPUT
+      #{BLANK_HDR}
+       <sections>
+           <figure id="_">
+        <pre id="_">&lt;LITERAL&gt;</pre>
         </figure>
        </sections>
        </metanorma>


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-ietf/issues/288
Closes https://github.com/metanorma/metanorma-ietf/issues/289

## Summary

Two small generator fixes handed over from the grammar census on the heritage corpus (they account for 205 of its 255 hits):

- **#288**: `ext/pi` was emitted last (after `showOnFrontPage`), but relaton-ietf models the PI container after `ipr?`, before `consensus?` — rejected purely on position. The emission moves to directly after `ipr`; the default-metadata fixture now asserts the modelled ext child order.
- **#289**: the IETF `literal` override predated base standoc's id-minting on `pre` and emitted `align`/`alt` only, so every unanchored literal produced an id-less `pre` (grammar has required `pre/@id` since the id/anchor split, basicdoc-models#32). The override now mirrors base standoc's `pre_attrs` (id minted, anchor stays on the figure), keeping the `align` passthrough. New spec covers the previously untested unanchored path.

🤖
