### PR TITLE
Move IetfDocument model from metanorma-document to metanorma-ietf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,18 @@
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
-
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
+
+# TEMPORARY: cross-PR branch pins so CI can resolve the in-flight
+# metanorma-standoc namespace rename (Metanorma::Standoc::Document)
+# and the pubid-2 / relaton-bib 2.2 / metanorma-document 0.5 chain.
+# Revert each pin once the corresponding PR merges:
+#   - https://github.com/metanorma/metanorma-standoc/pull/1232
+#   - https://github.com/metanorma/metanorma-document/pull/45
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "isodoc", github: "metanorma/isodoc", branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid", github: "pubid/pubid", branch: "main"
 
 eval_gemfile("Gemfile.devel") rescue nil

--- a/lib/metanorma/ietf.rb
+++ b/lib/metanorma/ietf.rb
@@ -1,4 +1,5 @@
 require_relative "ietf/processor"
+require "metanorma/ietf/document"
 require_relative "ietf/version"
 
 module Metanorma

--- a/lib/metanorma/ietf/document.rb
+++ b/lib/metanorma/ietf/document.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+# Forward-declare parent namespace so this file is safe to require
+# directly (without first requiring metanorma/ietf.rb).
+module Metanorma
+  module Ietf
+  end
+end
+
+
+module Metanorma
+  module Ietf::Document
+    autoload :Metadata, "metanorma/ietf/document/metadata"
+    autoload :Root, "metanorma/ietf/document/root"
+    autoload :Sections, "metanorma/ietf/document/sections"
+  end
+end
+
+
+# Backwards-compat alias so external consumers that reference
+# Metanorma::IetfDocument keep resolving during the transition.
+module Metanorma
+  existing = defined?(Metanorma::IetfDocument) && Metanorma::IetfDocument
+  if !existing.equal?(Metanorma::Ietf::Document)
+    Metanorma.send(:remove_const, :IetfDocument) if existing
+    IetfDocument = Metanorma::Ietf::Document
+  end
+end
+
+if defined?(Metanorma::Registers::Setup.setup_ietf_register)
+  Metanorma::Registers::Setup.setup_ietf_register
+end
+
+module Metanorma
+  deprecate_constant :IetfDocument
+end

--- a/lib/metanorma/ietf/document/metadata.rb
+++ b/lib/metanorma/ietf/document/metadata.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      autoload :IetfBibDataExtensionType,
+               "metanorma/ietf/document/metadata/ietf_bib_data_extension_type"
+      autoload :IetfBibliographicItem,
+               "metanorma/ietf/document/metadata/ietf_bibliographic_item"
+      autoload :IetfEditorialGroup,
+               "metanorma/ietf/document/metadata/ietf_editorial_group"
+      autoload :PiSettings,
+               "metanorma/ietf/document/metadata/pi_settings"
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/ietf_bib_data_extension_type.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_bib_data_extension_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class IetfBibDataExtensionType < Lutaml::Model::Serializable
+        attribute :doctype, :string
+        attribute :flavor, :string
+        attribute :ipr, :string
+        attribute :consensus, :string
+        attribute :area, :string, collection: true
+        attribute :submission_type, :string
+        attribute :editorial_group, IetfEditorialGroup
+        attribute :pi, PiSettings
+
+        xml do
+          element "ext"
+          map_element "doctype", to: :doctype
+          map_element "flavor", to: :flavor
+          map_element "ipr", to: :ipr
+          map_element "consensus", to: :consensus
+          map_element "area", to: :area
+          map_element "submissionType", to: :submission_type
+          map_element "editorial-group", to: :editorial_group
+          map_element "editorialgroup", to: :editorial_group
+          map_element "pi", to: :pi
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/ietf_bibliographic_item.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_bibliographic_item.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class IetfBibliographicItem < Metanorma::Document::Components::BibData::BibliographicItem
+        attribute :ext, Metanorma::Ietf::Document::Metadata::IetfBibDataExtensionType
+
+        xml do
+          element "bibdata"
+          map_attribute "type", to: :type_attr
+          map_attribute "schema-version", to: :schema_version
+          map_element "fetched", to: :fetched
+          map_element "title", to: :title
+          map_element "formattedref", to: :formatted_ref
+          map_element "uri", to: :link
+          map_element "docidentifier", to: :docidentifier
+          map_element "docnumber", to: :docnumber
+          map_element "date", to: :date
+          map_element "contributor", to: :contributor
+          map_element "edition", to: :edition
+          map_element "version", to: :version
+          map_element "note", to: :note
+          map_element "language", to: :language
+          map_element "script", to: :script
+          map_element "abstract", to: :abstract
+          map_element "status", to: :status
+          map_element "copyright", to: :copyright
+          map_element "relation", to: :relation
+          map_element "series", to: :series
+          map_element "medium", to: :medium
+          map_element "place", to: :place
+          map_element "price", to: :price
+          map_element "extent", to: :extent
+          map_element "size", to: :size
+          map_element "accessLocation", to: :access_location
+          map_element "license", to: :license
+          map_element "classification", to: :classification
+          map_element "keyword", to: :keyword
+          map_element "validity", to: :validity
+          map_element "ext", to: :ext
+          map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
+          map_attribute "semx-id", to: :semx_id
+          map_attribute "schema-version", to: :schema_version
+          map_element "biblio-tag", to: :biblio_tag
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/ietf_editorial_group.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_editorial_group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      # IETF editorial group containing workgroup names.
+      class IetfEditorialGroup < Lutaml::Model::Serializable
+        attribute :workgroup, :string, collection: true
+
+        xml do
+          element "editorialgroup"
+          map_element "workgroup", to: :workgroup
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/pi_settings.rb
+++ b/lib/metanorma/ietf/document/metadata/pi_settings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class PiSettings < Lutaml::Model::Serializable
+        attribute :toc, :string
+        attribute :tocdepth, :string
+        attribute :symrefs, :string
+        attribute :sortrefs, :string
+        attribute :compact, :string
+        attribute :subcompact, :string
+        attribute :strict, :string
+        attribute :comments, :string
+        attribute :notedraftinprogress, :string
+
+        xml do
+          element "pi"
+          map_element "toc", to: :toc
+          map_element "tocdepth", to: :tocdepth
+          map_element "symrefs", to: :symrefs
+          map_element "sortrefs", to: :sortrefs
+          map_element "compact", to: :compact
+          map_element "subcompact", to: :subcompact
+          map_element "strict", to: :strict
+          map_element "comments", to: :comments
+          map_element "notedraftinprogress", to: :notedraftinprogress
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/root.rb
+++ b/lib/metanorma/ietf/document/root.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Ietf::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::Standoc::Document::RootAttributes
+
+      def self.lutaml_default_register
+        :ietf_document
+      end
+
+      attribute :bibdata,
+                Metanorma::Ietf::Document::Metadata::IetfBibliographicItem
+      attribute :preface,
+                Metanorma::Standoc::Document::Sections::Preface
+      attribute :sections,
+                Metanorma::Ietf::Document::Sections::IetfSections
+      attribute :annex,
+                Metanorma::Ietf::Document::Sections::IetfAnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::Standoc::Document::Namespace
+
+        Metanorma::Standoc::Document::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections.rb
+++ b/lib/metanorma/ietf/document/sections.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      autoload :IetfSections, "#{__dir__}/sections/ietf_sections"
+      autoload :IetfContentSection, "#{__dir__}/sections/ietf_content_section"
+      autoload :IetfClauseSection, "#{__dir__}/sections/ietf_clause_section"
+      autoload :IetfAnnexSection, "#{__dir__}/sections/ietf_annex_section"
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfAnnexSection < Metanorma::Standoc::Document::Sections::AnnexSection
+        # IETF-specific attributes
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Sub-clauses within IETF annex use IetfClauseSection
+        attribute :clause, IetfClauseSection, collection: true
+
+        xml do
+          element "annex"
+          ordered
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_attributes(self)
+          map_attribute "numbered",    to: :numbered
+          map_attribute "removeInRFC", to: :remove_in_rfc
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfClauseSection < Metanorma::Standoc::Document::Sections::ClauseSection
+        # IETF-specific attributes
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Recursive IETF sub-clauses
+        attribute :clause, IetfClauseSection, collection: true
+
+        xml do
+          element "clause"
+          ordered
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_clause_attributes(self)
+          map_attribute "numbered",    to: :numbered
+          map_attribute "removeInRFC", to: :remove_in_rfc
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_clause_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_content_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_content_section.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfContentSection < Metanorma::Standoc::Document::Sections::ContentSection
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Recursive IETF sub-clauses
+        attribute :subsection, IetfContentSection, collection: true
+
+        xml do
+          element "clause"
+          ordered
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_content_section_attributes(self)
+          map_attribute "numbered",       to: :numbered
+          map_attribute "removeInRFC",    to: :remove_in_rfc
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_content_section_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_sections.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_sections.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      # IETF sections container.
+      # Corresponds to ietf.rnc:
+      #   sections = element sections {
+      #     ( clause | terms | term-clause | definitions | floating-title )+
+      #   }
+      #
+      # Extends StandardDocument sections with loose bibitem references
+      # and paragraph elements directly inside sections.
+      class IetfSections < Metanorma::Standoc::Document::Sections::Sections
+        attribute :bibitem,
+                  Metanorma::BasicDocument::BibData::BibliographicItem,
+                  collection: true
+        attribute :p,
+                  Metanorma::Document::Components::Paragraphs::ParagraphBlock,
+                  collection: true
+
+        xml do
+          element "sections"
+          ordered
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_sections_elements(self)
+          map_element "bibitem",        to: :bibitem
+          map_element "p",              to: :p
+
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_sections_attributes(self)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/ietf/example/document.xml
+++ b/spec/fixtures/ietf/example/document.xml
@@ -1,0 +1,658 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metanorma xmlns="https://www.metanorma.org/ns/standoc" type="semantic" version="3.7.5" schema-version="v2.1.6" flavor="ietf">
+<bibdata type="standard">
+<title language="en" type="abbrev">IP Datagrams on Avian Carriers</title>
+
+<title language="en" type="main">RFC XML v3 Example: A Standard for the Transmission of IP Datagrams on Avian Carriers</title>
+<docidentifier primary="true">1149</docidentifier><docnumber>1149</docnumber><date type="updated"><on>1990-04-01</on></date><contributor><role type="author"/><person>
+<name><forename>David</forename><surname>Waitzman</surname></name>
+<affiliation><organization>
+<name>BBN STC</name>
+<address><formattedAddress>10 Moulton Street<br/>Cambridge<br/>MA 02238</formattedAddress></address></organization></affiliation><phone>(617) 873-4323</phone><email>dwaitzman@BBN.COM</email><uri>http://bbn.com</uri></person></contributor><contributor><role type="author"/><person>
+<name><forename>Nick</forename><surname>Nicholas</surname></name>
+<affiliation><organization>
+<name>BBN STC</name>
+<address><formattedAddress>10 Moulton Street<br/>Cambridge<br/>MA 02238</formattedAddress></address></organization></affiliation><phone>(617) 873-4323</phone><email>opoudjis@gmail.com</email><uri>http://opoudjis.net</uri></person></contributor><contributor><role type="author"><description>committee</description></role><organization>
+<name>Internet Engineering Task Force</name>
+<subdivision type="Workgroup">
+<name>Network Working Group</name>
+</subdivision><abbreviation>IETF</abbreviation></organization></contributor><contributor><role type="publisher"/><organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation></organization></contributor><version>1990-04-01</version><language>en</language><script>Latn</script><status><stage>published</stage></status><copyright><from>2026</from><owner><organization>
+<name>Internet Engineering Task Force</name>
+<abbreviation>IETF</abbreviation></organization></owner></copyright><relation type="derivedFrom">
+<bibitem type="standard" schema-version="v1.5.6">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">Standard for the transmission of IP datagrams on avian carriers</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc1149</uri>
+  <docidentifier type="IETF" primary="true">RFC 1149</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC1149</docidentifier>
+  <docnumber>RFC1149</docnumber>
+  <date type="published">
+    <on>1990-04</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">D.</formatted-initials>          <surname language="en" script="Latn">Waitzman</surname>          <completename language="en" script="Latn">D. Waitzman</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p>This memo describes an experimental method for the encapsulation of IP datagrams in avian carriers.  This specification is primarily useful in Metropolitan Area Networks.  This is an experimental, not recommended standard.</p>
+
+  </abstract>
+  <status>
+    <stage>EXPERIMENTAL</stage>
+  </status>
+  <series>
+    
+<title>RFC</title>
+
+    <number>1149</number>
+  </series>
+  <series type="stream">
+    
+<title>INDEPENDENT</title>
+
+  </series>
+  <keyword>
+    <vocab>avian</vocab>
+  </keyword>
+  <keyword>
+    <vocab>carrier</vocab>
+  </keyword>
+  <keyword>
+    <vocab>april</vocab>
+  </keyword>
+  <keyword>
+    <vocab>fools</vocab>
+  </keyword>
+</bibitem>
+
+</relation><relation type="obsoletes">
+<bibitem type="standard" schema-version="v1.5.6">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">Request For Comments reference guide</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc1000</uri>
+  <docidentifier type="IETF" primary="true">RFC 1000</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC1000</docidentifier>
+  <docnumber>RFC1000</docnumber>
+  <date type="published">
+    <on>1987-08</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                              <formatted-initials language="en" script="Latn">J.K.</formatted-initials>          <surname language="en" script="Latn">Reynolds</surname>          <completename language="en" script="Latn">J.K. Reynolds</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">J.</formatted-initials>          <surname language="en" script="Latn">Postel</surname>          <completename language="en" script="Latn">J. Postel</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p>This RFC Reference Guide is intended to provide a historical account by categorizing and summarizing of the Request for Comments numbers 1 through 999 issued between the years 1969-1987.  These documents have been crossed referenced to indicate which RFCs are current, obsolete, or revised.</p>
+
+  </abstract>
+  <status>
+    <stage>UNKNOWN</stage>
+  </status>
+  <series>
+    
+<title>RFC</title>
+
+    <number>1000</number>
+  </series>
+  <series type="stream">
+    
+<title>Legacy</title>
+
+  </series>
+</bibitem>
+
+</relation><relation type="obsoletes">
+<bibitem type="standard" schema-version="v1.5.6">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">IAB official protocol standards</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc1200</uri>
+  <docidentifier type="IETF" primary="true">RFC 1200</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC1200</docidentifier>
+  <docnumber>RFC1200</docnumber>
+  <date type="published">
+    <on>1991-04</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <organization>
+      
+<name language="en">Defense Advanced Research Projects Agency</name>
+
+      <abbreviation language="en">DARPA</abbreviation>
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <organization>
+      
+<name language="en">Internet Activities Board</name>
+
+      <abbreviation language="en">IAB</abbreviation>
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p>This memo describes the state of standardization of protocols used in the Internet as determined by the Internet Activities Board (IAB).  An overview of the standards procedures is presented first, followed by discussions of the standardization process and the RFC document series, then the explanation of the terms is presented, the lists of protocols in each stage of standardization follows, and finally pointers to references and contacts for further information.</p>
+
+  </abstract>
+  <status>
+    <stage>HISTORIC</stage>
+  </status>
+  <relation type="obsoletedBy">
+    <bibitem>
+      <formattedref>RFC1250</formattedref>
+      <docidentifier type="IETF" primary="true">RFC1250</docidentifier>
+    </bibitem>
+
+  </relation>
+  <series>
+    
+<title>RFC</title>
+
+    <number>1200</number>
+  </series>
+  <series type="stream">
+    
+<title>Legacy</title>
+
+  </series>
+  <keyword>
+    <vocab>IAB</vocab>
+  </keyword>
+  <keyword>
+    <vocab>official</vocab>
+  </keyword>
+  <keyword>
+    <vocab>protocol</vocab>
+  </keyword>
+  <keyword>
+    <vocab>standards</vocab>
+  </keyword>
+</bibitem>
+
+</relation><relation type="updates">
+<bibitem type="standard" schema-version="v1.5.6">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">Operational Criteria for Root Name Servers</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc2010</uri>
+  <docidentifier type="IETF" primary="true">RFC 2010</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC2010</docidentifier>
+  <docnumber>RFC2010</docnumber>
+  <date type="published">
+    <on>1996-10</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">B.</formatted-initials>          <surname language="en" script="Latn">Manning</surname>          <completename language="en" script="Latn">B. Manning</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">P.</formatted-initials>          <surname language="en" script="Latn">Vixie</surname>          <completename language="en" script="Latn">P. Vixie</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p>This document specifies the operational requirements of root name servers, including host hardware capacities, name server software revisions, network connectivity, and physical environment.  This memo provides information for the Internet community.  This memo does not specify an Internet standard of any kind.</p>
+
+  </abstract>
+  <status>
+    <stage>INFORMATIONAL</stage>
+  </status>
+  <relation type="obsoletedBy">
+    <bibitem>
+      <formattedref>RFC2870</formattedref>
+      <docidentifier type="IETF" primary="true">RFC2870</docidentifier>
+    </bibitem>
+
+  </relation>
+  <series>
+    
+<title>RFC</title>
+
+    <number>2010</number>
+  </series>
+  <series type="stream">
+    
+<title>Legacy</title>
+
+  </series>
+  <keyword>
+    <vocab>host</vocab>
+  </keyword>
+  <keyword>
+    <vocab>hardware</vocab>
+  </keyword>
+</bibitem>
+
+</relation><relation type="updates">
+<bibitem type="standard" schema-version="v1.5.6">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">Managing the X.500 Root Naming Context</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc2120</uri>
+  <docidentifier type="IETF" primary="true">RFC 2120</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC2120</docidentifier>
+  <docnumber>RFC2120</docnumber>
+  <date type="published">
+    <on>1997-03</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">D.</formatted-initials>          <surname language="en" script="Latn">Chadwick</surname>          <completename language="en" script="Latn">D. Chadwick</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="author">
+      <description>committee</description>
+    </role>
+    <organization>
+      
+<name language="en">Internet Engineering Task Force</name>
+
+      <subdivision type="workgroup">
+        
+<name>Integrated Directory Services</name>
+
+        <identifier>ids</identifier>
+      </subdivision>
+      <abbreviation language="en">IETF</abbreviation>
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p>This document describes the use of 1993 ISO X.500 Standard protocols for managing the root context.  Whilst the ASN.1 is compatible with that of the X.500 Standard, the actual settings of the parameters are supplementary to that of the X.500 Standard.  This memo defines an Experimental Protocol for the Internet community.</p>
+
+  </abstract>
+  <status>
+    <stage>EXPERIMENTAL</stage>
+  </status>
+  <series>
+    
+<title>RFC</title>
+
+    <number>2120</number>
+  </series>
+  <series type="stream">
+    
+<title>IETF</title>
+
+  </series>
+  <keyword>
+    <vocab>X.500-NAME</vocab>
+  </keyword>
+  <keyword>
+    <vocab>ISO</vocab>
+  </keyword>
+  <keyword>
+    <vocab>International</vocab>
+  </keyword>
+  <keyword>
+    <vocab>Standards</vocab>
+  </keyword>
+  <keyword>
+    <vocab>Organization</vocab>
+  </keyword>
+</bibitem>
+
+</relation><series type="stream">
+<title>IETF</title>
+</series><series type="intended">
+<title>full-standard</title>
+</series><ext><doctype>rfc</doctype><flavor>ietf</flavor><area>Internet</area><ipr>trust200902</ipr><consensus>true</consensus><pi><tocinclude>yes</tocinclude></pi></ext></bibdata><metanorma-extension><semantic-metadata><stage-published>true</stage-published></semantic-metadata>
+<presentation-metadata><toc-heading-levels>2</toc-heading-levels><html-toc-heading-levels>2</html-toc-heading-levels><doc-toc-heading-levels>2</doc-toc-heading-levels><pdf-toc-heading-levels>2</pdf-toc-heading-levels></presentation-metadata></metanorma-extension>
+<preface><foreword id="_d8b1be11-c587-1651-f748-8c6a5eae1d3a" obligation="informative">
+<title id="_41c9fad3-d4c1-eecc-4fad-f91704acc026">Foreword</title>
+<p id="_c72e4364-d18b-73a9-cd8a-737e1c55eed6">Avian carriers can provide high delay, low throughput, and low altitude service.  The connection topology is limited to a single point-to-point path for each carrier, used with standard carriers, but many carriers can be used without significant interference with each other, outside of early spring.  This is because of the 3D ether space available to the carriers, in contrast to the 1D ether used by IEEE802.3.  The carriers have an intrinsic collision avoidance system, which increases availability.  Unlike some network technologies, such as packet radio, communication is not limited to line-of-sight distance.  Connection oriented service is available in some cities, usually based upon a central hub topology.</p>
+
+<note id="_31ef9267-2dec-6024-152f-45fc443fc8ab"><p id="_f904fd0b-239f-7903-55b5-3057711da163">Yes, this is an April Fool's RFC.</p>
+</note>
+</foreword></preface><sections>
+<clause id="_7db07fdc-fcc6-b1d5-fbd9-4af3fe5d67d4" anchor="frame" inline-header="false" obligation="normative">
+<title id="_7f507f76-d16f-6909-7c72-3bf386b1aac3">Frame Format</title>
+<p id="_e5b93d18-9b70-055e-f3ea-e7d3e221cb31">The IP <em>datagram</em> is <strong>printed</strong>, on a small scroll of paper, in hexadecimal, with each octet separated by whitestuff and blackstuff. The scroll of paper is wrapped around one leg of the avian carrier. A band of duct tape is used to secure the datagram's edges.  The bandwidth is limited to the leg length.  The MTU is variable, and paradoxically, generally increases with increased carrier age.  A typical MTU is 256 milligrams.  Some datagram padding may be needed.<eref type="inline" bibitemid="RFC7253" citeas="RFC 7253"><display-text>alt</display-text></eref></p>
+
+<p id="_cbfa7d28-50f5-f4d4-8920-3ff81bb853de">Upon receipt, the duct tape is removed and the paper copy of the datagram is optically scanned into a electronically transmittable form.<eref type="inline" bibitemid="RFC7253" citeas="RFC 7253"/></p>
+
+<p id="_fc8f9bad-4c2e-b401-b3d3-cb0f27d860c0">This document extends OpenPGP and its ECC extension to support SM2, SM3 and SM4:</p>
+
+<ul id="_11114aa2-d4d3-dc06-3f39-b73ad2a1e845"><li><p id="_98a97c6d-e43a-046f-92b7-a86350931f2a">support the SM3 hash algorithm for data validation purposes</p>
+</li>
+<li><p id="_8486d222-630f-43b8-c65b-10549d192419">support signatures utilizing the combination of SM3 with other digital signing algorithms, such as RSA, ECDSA and SM2</p>
+</li>
+<li><p id="_268cc9bf-7e8f-315e-2c10-6a7d73687574">support the SM2 asymmetric encryption algorithm for public key operations</p>
+</li>
+<li><p id="_255af7b3-c69e-c5a5-56fc-bde30fbf3df3">support usage of SM2 in combination with supported hash algorithms, such as SHA-256 and SM3</p>
+</li>
+<li><p id="_8f08871f-baf2-3786-e40d-16949089bea8">support the SM4 symmetric encryption algorithm for data protection purposes</p>
+</li>
+<li><p id="_fb103500-02ce-e0fc-ac73-cb9107a94fbb">defines the OpenPGP profile "OSCCA-SM234" to enable usage of OpenPGP in an OSCCA-compliant manner.</p>
+</li>
+</ul>
+
+<p id="_4b2313ce-fea3-eceb-2685-e9273bfe3c5f">Algorithm-Specific Fields for SM2DSA keys:</p>
+
+<ul id="_89dbcd4e-108d-9cf0-7ed6-9b0ef9295fa2"><li><p id="_fe06d2f8-ca68-409e-9de1-b5bc9a808ed0">a variable-length field containing a curve OID, formatted as follows:</p>
+<ol id="_17a18a84-e68b-f34c-7ca5-11679fb126bf" type="alphabet"><li><p id="_3eb09fc7-ad4f-4770-c225-3eff8dda6773">a one-octet size of the following field; values 0 and 0xFF are reserved for future extensions</p>
+</li>
+<li><p id="_6136e5a8-c212-93d7-c60f-1cd13370e58e">octets representing a curve OID.</p>
+</li>
+</ol>
+</li>
+<li><p id="_82b05769-7668-5b78-21e8-4b845ca516e6">MPI of an EC point representing a public key</p>
+</li>
+</ul>
+
+<clause id="_b1474689-968c-d908-ec3c-52106a8e875b" inline-header="false" obligation="normative">
+<title id="_0615fb18-bab7-fcce-7fe6-b06f78cdb707">Definitions</title>
+<dl id="_188c1a32-874f-ef99-a4e5-24156e77be2b"><dt>OSCCA-compliant:</dt>
+<dd id="_2c9455c4-4da3-7bc6-4086-0552e4f2e2d7"><p id="_5adcd946-10f3-f180-1cbb-f92b4fabcca2">All cryptographic algorithms used are compliant with OSCCA  regulations.</p>
+</dd>
+<dt>SM2DSA:</dt>
+<dd id="_7b3b9b29-a8d6-5212-a466-05a95dc958b8"><p id="_d180edc5-58f8-2e9c-b0fe-e8bc3c1dc0f2">The elliptic curve digital signature algorithm. <eref type="inline" bibitemid="ISO.IEC.10118-3" citeas="ISO/IEC 10118-3"/></p>
+</dd>
+<dt>SM2KEP:</dt>
+<dd id="_8b7e1db2-3e31-e655-5f70-c3c628b2333a"><p id="_25816a40-fcab-ddd3-59c1-c36e64922ead">The elliptic curve key exchange protocol.</p>
+</dd>
+<dt>SM2PKE:</dt>
+<dd id="_0116d3dc-faf1-2b5c-6d96-3d0e43c0319c"><p id="_987ddefc-c7ab-b1a9-8e61-63fffb1d2c9e">The public key encryption algorithm.</p>
+</dd>
+</dl>
+
+<clause id="_6fba1756-f50c-b73f-e7ae-de44b06779dd" inline-header="false" obligation="normative">
+<title id="_e5c05521-6e9f-c226-9867-b510573a6031">Elliptic Curve Formula</title>
+<formula id="_715e97cf-cc6f-9198-2c02-2a02635bb1a7"><stem block="true" type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="true">
+    <msup>
+      <mi>y</mi>
+      <mn>2</mn>
+    </msup>
+    <mo>=</mo>
+    <msup>
+      <mi>x</mi>
+      <mn>3</mn>
+    </msup>
+    <mo>+</mo>
+    <mi>a</mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>b</mi>
+  </mstyle>
+</math><asciimath>y^2 = x^3 + ax + b</asciimath></stem></formula>
+</clause>
+
+<clause id="_0668a897-0729-7359-eab6-8d077ee7d57e" inline-header="false" obligation="normative">
+<title id="_f72a1b8a-26da-a612-fff6-cb3044394ac5">Curve Parameters</title>
+<figure id="_38f5804e-e275-ab99-08ac-4c30d1b4a706" anchor="curveparam1">
+<name id="_59c73436-21a8-490f-957a-38b2088d4c34">Curve Parameters Listing</name>
+<pre>p   = FFFFFFFE FFFFFFFF FFFFFFFF FFFFFFFF
+      FFFFFFFF 00000000 FFFFFFFF FFFFFFFF
+a   = FFFFFFFE FFFFFFFF FFFFFFFF FFFFFFFF
+      FFFFFFFF 00000000 FFFFFFFF FFFFFFFC
+b   = 28E9FA9E 9D9F5E34 4D5A9E4B CF6509A7
+      F39789F5 15AB8F92 DDBCBD41 4D940E93
+n   = FFFFFFFE FFFFFFFF FFFFFFFF FFFFFFFF
+      7203DF6B 21C6052B 53BBF409 39D54123
+x_G = 32C4AE2C 1F198119 5F990446 6A39C994
+      8FE30BBF F2660BE1 715A4589 334C74C7
+y_G = BC3736A2 F4F6779C 59BDCEE3 6B692153
+      D0A9877C C62A4740 02DF32E5 2139F0A0</pre></figure>
+</clause>
+</clause>
+</clause>
+
+<clause id="_d5a85061-7303-41bd-5529-02ec3201dfe0" inline-header="false" obligation="normative">
+<title id="_c27516a5-6e4f-4ec8-a61e-b5068e8bd886">Code to launch spaceship</title>
+<sourcecode id="_8abc4413-b0aa-2586-57e2-b7d8276f1e34" lang="ruby"><body>&lt;CODE BEGINS&gt;
+module Foo
+  class Bar
+    def prepare_launch(spaceship, rocket)
+      spaceship.load_personnel
+      rocket.load(spaceship)
+      rocket
+    end
+  end
+end
+&lt;CODE ENDS&gt;</body></sourcecode>
+
+</clause>
+
+<clause id="_d9df8192-4e34-7d26-aaf2-3a74d971dbc1" inline-header="false" obligation="normative">
+<title id="_b1a9a7a3-261d-d749-2e1f-9bdade213f54">Supported Algorithms</title>
+<clause id="_131fa81d-7b45-e79d-ae30-55d9a9944512" inline-header="false" obligation="normative">
+<title id="_3ac8ad3b-f341-575b-0040-5ee1acf3a29c">Public Key Algorithms</title>
+<p id="_dbf9c7d4-7e2b-f423-6695-bfa7f24883c5">The SM2 algorithm is supported with the following extension.</p>
+
+<note id="_eeef76c5-c355-62fd-62be-150d1905b285"><p id="_d571ae80-753f-6a4c-7ad5-1f8758363e86">ECDH is defined in Section 8 of this document.</p>
+</note>
+
+<p id="_5555327b-ccda-8f33-5ca9-d63c61d41122">The following public key algorithm IDs are added to expand Section 9.1 of RFC4880, "Public-Key Algorithms":</p>
+
+<table id="_1989e233-0cf6-dc99-4526-e418f56d3465">
+<name id="_c1ed91d5-95cd-1165-ac36-7b3fb8bbaa2e">Table 2</name>
+<thead><tr id="_1be4ba81-2d3d-5477-18b0-d0f4fb194075"><th id="_d70cd83b-1ca4-750f-d351-7b8d5db90aa5" valign="top" align="left">ID</th>
+<th id="_8c2ec212-6ffc-bebf-42a3-ec5fb9b49bd3" valign="top" align="left">Description of Algorithm</th>
+</tr></thead>
+<tbody><tr id="_e5c4edf2-3aa6-0e06-c62a-1879abd9a991"><td id="_8a436298-f5e7-8475-f6fc-030e5c8f6b3f" valign="top" align="left">TBD</td>
+<td id="_44a40bdb-8e34-d724-d540-c1b5308eed0c" valign="top" align="left">SM2</td>
+</tr></tbody>
+</table>
+</clause>
+</clause>
+
+<clause id="_c1643524-e296-14ab-92b8-5a12f4f44ece" inline-header="false" obligation="normative">
+<title id="_645dcf20-0b3a-7d83-b7d0-00cc74831140">Security Considerations</title>
+<p id="_84ba58f1-507c-e7eb-23e2-982c6903e8c4">Security is not generally a problem in normal operation, but special<br/> measures  <span class="bcp14">MUST</span> be taken (such as data encryption) when avian carriers are used in a tactical environment.<eref type="inline" bibitemid="RFC7253" citeas="RFC 7253"/>, <eref type="inline" bibitemid="ISO.IEC.10118-3" citeas="ISO/IEC 10118-3"/></p>
+</clause>
+
+
+
+
+</sections><bibliography><references id="_f46be799-926b-e78f-ab62-73e11bfafdbf" normative="false" obligation="informative">
+<title id="_a49f7782-d850-ca98-828b-7466eb53a469">Normative  References</title><bibitem anchor="ISO.IEC.10118-3" id="_f91d73e7-5f5f-a9aa-26df-56b66ac0f61b" type="standard">
+<docidentifier type="ISO">ISO/IEC 10118-3</docidentifier><docnumber>10118-3</docnumber><contributor><role type="publisher"/><organization>
+<name>ISO</name>
+</organization></contributor><contributor><role type="publisher"/><organization>
+<name>IEC</name>
+</organization></contributor><language>en</language><script>Latn</script></bibitem>
+
+</references><references id="_46aa1c09-4c33-c329-3e5d-d014f838163d" normative="false" obligation="informative">
+<title id="_d78142cf-fee4-7aa4-bf03-fef36ffffd4a">Informative References</title><bibitem id="_9357d6f0-ef39-fc9c-320f-a82406a4e16c" type="standard" schema-version="v1.5.6" anchor="RFC7253">
+  <fetched>2026-06-19</fetched>
+  
+<title type="main">The OCB Authenticated-Encryption Algorithm</title>
+
+  <uri type="src">https://www.rfc-editor.org/info/rfc7253</uri>
+  <docidentifier type="IETF" primary="true">RFC 7253</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC7253</docidentifier>
+  <docnumber>RFC7253</docnumber>
+  <date type="published">
+    <on>2014-05</on>
+  </date>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">T.</formatted-initials>          <surname language="en" script="Latn">Krovetz</surname>          <completename language="en" script="Latn">T. Krovetz</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="author"/>
+    <person>
+      
+<name>                    <formatted-initials language="en" script="Latn">P.</formatted-initials>          <surname language="en" script="Latn">Rogaway</surname>          <completename language="en" script="Latn">P. Rogaway</completename>       </name>
+
+    </person>
+  </contributor>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      
+<name language="en">RFC Publisher</name>
+
+    </organization>
+  </contributor>
+  <contributor>
+    <role type="authorizer"/>
+    <organization>
+      
+<name language="en">RFC Series</name>
+
+    </organization>
+  </contributor>
+  <language>en</language>
+  <script>Latn</script>
+  <abstract language="en" script="Latn">
+    <p id="_2a409525-de79-3dca-f16e-919a3474346b">This document specifies OCB, a shared-key blockcipher-based encryption scheme that provides confidentiality and authenticity for plaintexts and authenticity for associated data.  This document is a product of the Crypto Forum Research Group (CFRG).</p>
+
+  </abstract>
+  <status>
+    <stage>INFORMATIONAL</stage>
+  </status>
+  <series>
+    
+<title>RFC</title>
+
+    <number>7253</number>
+  </series>
+  <series type="stream">
+    
+<title>IRTF</title>
+
+  </series>
+  <keyword>
+    <vocab>OCB</vocab>
+  </keyword>
+  <keyword>
+    <vocab>AEAD</vocab>
+  </keyword>
+  <keyword>
+    <vocab>authenticated-encryption</vocab>
+  </keyword>
+</bibitem>
+
+</references></bibliography>
+</metanorma>

--- a/spec/ietf_document_namespace_spec.rb
+++ b/spec/ietf_document_namespace_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Metanorma::Ietf::Document namespace" do
+  describe "canonical namespace" do
+    it "exposes Metanorma::Ietf::Document as a Module" do
+      expect(Metanorma::Ietf::Document).to be_a(Module)
+    end
+
+    it "exposes Root with the canonical name" do
+      expect(Metanorma::Ietf::Document::Root.name)
+        .to eq("Metanorma::Ietf::Document::Root")
+    end
+
+    it "Root is a lutaml Serializable" do
+      expect(Metanorma::Ietf::Document::Root < Lutaml::Model::Serializable).to be(true)
+    end
+  end
+
+  describe "backwards-compat alias" do
+    it "Metanorma::IetfDocument aliases to the new namespace" do
+      expect(Metanorma::IetfDocument).to eq(Metanorma::Ietf::Document)
+    end
+
+    it "the alias preserves class identity" do
+      expect(Metanorma::IetfDocument::Root.equal?(
+               Metanorma::Ietf::Document::Root)).to be(true)
+    end
+  end
+
+  describe "parent namespace" do
+    it "Metanorma::Standoc::Document is available" do
+      expect(Metanorma::Standoc::Document).to be_a(Module)
+    end
+
+    it "Metanorma::StandardDocument alias is available" do
+      expect(Metanorma::StandardDocument).to eq(Metanorma::Standoc::Document)
+    end
+  end
+end

--- a/spec/ietf_roundtrip_spec.rb
+++ b/spec/ietf_roundtrip_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rspec/matchers"
+require "metanorma/ietf/document"
+require_relative "support/roundtrip_helper"
+require_relative "support/shared_roundtrip_examples"
+
+RSpec.describe "IETF document XML round-trip" do
+  it_behaves_like "xml round-trip", flavor_dir: "ietf",
+                                    doc_class: Metanorma::Ietf::Document::Root
+end

--- a/spec/support/roundtrip_helper.rb
+++ b/spec/support/roundtrip_helper.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module RoundtripHelper
+  FIXTURES_DIR = File.expand_path("../fixtures", __dir__)
+
+  # Discover all non-collection XML fixtures for a flavor directory.
+  # Returns Array<Hash> with :name, :path, :flavor_dir, :xml_type keys.
+  def self.discover_fixtures(flavor_dir: nil)
+    base = File.join(FIXTURES_DIR, flavor_dir)
+    Dir[File.join(base, "**", "*.xml")].filter_map do |path|
+      next if path.include?("/collection/")
+      next if collection_xml?(path)
+
+      name = build_name(path)
+      xml_type = path.end_with?(".presentation.xml") ? "presentation" : "semantic"
+
+      { name: name, path: path, flavor_dir: flavor_dir, xml_type: xml_type }
+    end
+  end
+
+  # Discover collection XML fixtures.
+  # Returns Array<Hash> with :name, :path, :xml_type keys.
+  def self.discover_collections(flavor_dir: nil)
+    base = File.join(FIXTURES_DIR, flavor_dir)
+    Dir[File.join(base, "collection", "collection*.xml")].map do |path|
+      name = File.basename(path, ".xml")
+      xml_type = path.end_with?(".presentation.xml") ? "presentation" : "semantic"
+
+      { name: name, path: path, xml_type: xml_type }
+    end
+  end
+
+  # Parse XML with Nokogiri, strip namespaces for consistent CSS selectors.
+  def self.parse_xml(xml_string)
+    doc = Nokogiri::XML(xml_string, &:noblanks)
+    doc.remove_namespaces!
+    doc
+  end
+
+  # Check for ERROR-level parse errors.
+  def self.xml_has_errors?(xml_string)
+    doc = Nokogiri::XML(xml_string)
+    doc.errors.any? { |e| e.type == Nokogiri::XML::SyntaxError::ERROR }
+  end
+
+  # Compute the read/parse/serialize/re-parse cycle ONCE per fixture for
+  # the whole suite. Roundtrip specs assert against these immutable
+  # artifacts; previously every example repeated the full cycle (up to
+  # 18 times per fixture — the dominant suite cost on multi-MB files).
+  def self.fixture_data(path, doc_class)
+    @fixture_data_cache ||= {}
+    @fixture_data_cache[[path, doc_class]] ||= begin
+      xml = File.read(path)
+      doc = doc_class.from_xml(xml)
+      output_xml = doc.to_xml
+      {
+        xml: xml,
+        doc: doc,
+        output_xml: output_xml,
+        original_noko: parse_xml(xml),
+        roundtrip_noko: parse_xml(output_xml),
+      }
+    end
+  end
+
+  # Extract root element attributes as a hash.
+  def self.root_attrs(doc)
+    root = doc.root
+    return {} unless root
+
+    { name: root.name, type: root["type"], flavor: root["flavor"],
+      version: root["version"] }
+  end
+
+  # Extract bibdata type attribute.
+  def self.bibdata_type(doc)
+    bibdata = doc.at_css("bibdata")
+    bibdata ? bibdata["type"] : nil
+  end
+
+  # Extract title elements as [language, type, text] triples.
+  def self.bibdata_titles(doc)
+    doc.css("bibdata > title").map do |t|
+      [t["language"], t["type"], t.text.strip]
+    end
+  end
+
+  # Extract status stage text.
+  def self.status_stage(doc)
+    doc.at_css("bibdata > status stage")&.text&.strip
+  end
+
+  # Extract top-level section clause IDs (sorted).
+  def self.section_clause_ids(doc)
+    doc.css("sections > clause").filter_map { |c| c["id"] }.sort
+  end
+
+  # Check if preface element exists.
+  def self.has_preface?(doc)
+    !doc.at_css("preface").nil?
+  end
+
+  # Extract annex IDs (sorted).
+  def self.annex_ids(doc)
+    doc.css("annex").filter_map { |a| a["id"] }.sort
+  end
+
+  # Count bibliography references sections.
+  def self.bibliography_references_count(doc)
+    doc.css("bibliography > references").length
+  end
+
+  # Extract bibliography normative attributes in order.
+  def self.bibliography_normative_attrs(doc)
+    doc.css("bibliography > references").map { |r| r["normative"] }
+  end
+
+  # Extract term IDs (sorted).
+  def self.term_ids(doc)
+    doc.css("term").filter_map { |t| t["id"] }.sort
+  end
+
+  # Extract table IDs (sorted).
+  def self.table_ids(doc)
+    doc.css("table").filter_map { |t| t["id"] }.sort
+  end
+
+  # Extract figure IDs (sorted).
+  def self.figure_ids(doc)
+    doc.css("figure").filter_map { |f| f["id"] }.sort
+  end
+
+  # Extract formula IDs (sorted).
+  def self.formula_ids(doc)
+    doc.css("formula").filter_map { |f| f["id"] }.sort
+  end
+
+  # Extract nested clause IDs — 2 levels deep (sorted).
+  def self.nested_clause_ids(doc)
+    doc.css("sections clause clause").filter_map { |c| c["id"] }.sort
+  end
+
+  # Count inline-header attributes.
+  def self.inline_header_count(doc)
+    doc.css("[inline-header]").length
+  end
+
+  # Collection-specific: count directive elements.
+  def self.collection_directive_count(doc)
+    doc.css("directive").length
+  end
+
+  # Collection-specific: count entry elements.
+  def self.collection_entry_count(doc)
+    doc.css("entry").length
+  end
+
+  # Collection-specific: count doc-container elements.
+  def self.doc_container_count(doc)
+    doc.css("doc-container").length
+  end
+
+  # Collection-specific: extract doc-container IDs.
+  def self.doc_container_ids(doc)
+    doc.css("doc-container").filter_map { |d| d["id"] }.sort
+  end
+
+  # Collection-specific: extract primary docidentifiers from embedded docs.
+  def self.doc_container_docidentifiers(doc)
+    doc.css("doc-container bibdata > docidentifier[primary]").map do |d|
+      d.text.strip
+    end.sort
+  end
+
+  class << self
+    private
+
+    def build_name(path)
+      rel = path.sub("#{FIXTURES_DIR}/", "")
+      rel.sub(/\.xml$/, "")
+    end
+
+    def collection_xml?(path)
+      content = File.read(path, 200)
+      content.include?("<metanorma-collection")
+    end
+  end
+end

--- a/spec/support/shared_roundtrip_examples.rb
+++ b/spec/support/shared_roundtrip_examples.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+# Shared examples for XML round-trip specs.
+# Use in spec files via:
+#   it_behaves_like "xml round-trip", flavor_dir: "ogc", doc_class: nil
+RSpec.shared_examples "xml round-trip" do |flavor_dir:, doc_class: nil, full: true|
+  fixtures = RoundtripHelper.discover_fixtures(flavor_dir: flavor_dir)
+
+  fixtures.each do |fixture|
+    describe fixture[:name] do
+      let(:data) { RoundtripHelper.fixture_data(fixture[:path], doc_class) }
+      let(:xml) { data[:xml] }
+      let(:doc) { data[:doc] }
+      let(:output_xml) { data[:output_xml] }
+      let(:original_noko) { data[:original_noko] }
+      let(:roundtrip_noko) { data[:roundtrip_noko] }
+
+      it "parses without error" do
+        expect(doc).to be_a(doc_class)
+      end
+
+      it "produces valid XML" do
+        expect(RoundtripHelper).not_to be_xml_has_errors(output_xml)
+      end
+
+      it "round-trips root element and attributes" do
+        expect(roundtrip_noko.root.name).to eq("metanorma")
+        expect(roundtrip_noko.root["type"]).to eq(original_noko.root["type"])
+        expect(roundtrip_noko.root["flavor"]).to eq(original_noko.root["flavor"])
+      end
+
+      it "round-trips bibdata type" do
+        expect(RoundtripHelper.bibdata_type(roundtrip_noko)).to eq(RoundtripHelper.bibdata_type(original_noko))
+      end
+
+      it "round-trips titles" do
+        expect(RoundtripHelper.bibdata_titles(roundtrip_noko)).to eq(RoundtripHelper.bibdata_titles(original_noko))
+      end
+
+      it "round-trips status stage" do
+        expect(RoundtripHelper.status_stage(roundtrip_noko)).to eq(RoundtripHelper.status_stage(original_noko))
+      end
+
+      it "round-trips section clause IDs" do
+        expect(RoundtripHelper.section_clause_ids(roundtrip_noko)).to eq(RoundtripHelper.section_clause_ids(original_noko))
+      end
+
+      it "round-trips preface" do
+        expect(RoundtripHelper.has_preface?(roundtrip_noko)).to eq(RoundtripHelper.has_preface?(original_noko))
+      end
+
+      it "round-trips annex IDs" do
+        expect(RoundtripHelper.annex_ids(roundtrip_noko)).to eq(RoundtripHelper.annex_ids(original_noko))
+      end
+
+      it "round-trips bibliography references sections" do
+        expect(RoundtripHelper.bibliography_references_count(roundtrip_noko)).to eq(RoundtripHelper.bibliography_references_count(original_noko))
+      end
+
+      it "round-trips bibliography normative attributes" do
+        expect(RoundtripHelper.bibliography_normative_attrs(roundtrip_noko)).to eq(RoundtripHelper.bibliography_normative_attrs(original_noko))
+      end
+
+      if full
+        it "round-trips term IDs" do
+          expect(RoundtripHelper.term_ids(roundtrip_noko)).to eq(RoundtripHelper.term_ids(original_noko))
+        end
+
+        it "round-trips table IDs" do
+          expect(RoundtripHelper.table_ids(roundtrip_noko)).to eq(RoundtripHelper.table_ids(original_noko))
+        end
+
+        it "round-trips figure IDs" do
+          expect(RoundtripHelper.figure_ids(roundtrip_noko)).to eq(RoundtripHelper.figure_ids(original_noko))
+        end
+
+        it "round-trips formula IDs" do
+          expect(RoundtripHelper.formula_ids(roundtrip_noko)).to eq(RoundtripHelper.formula_ids(original_noko))
+        end
+
+        it "round-trips nested clause structure" do
+          expect(RoundtripHelper.nested_clause_ids(roundtrip_noko)).to eq(RoundtripHelper.nested_clause_ids(original_noko))
+        end
+      end
+
+      if fixture[:xml_type] == "presentation"
+        it "preserves type=presentation on root" do
+          expect(roundtrip_noko.root["type"]).to eq("presentation")
+        end
+
+        if full
+          it "round-trips inline-header attributes" do
+            expect(RoundtripHelper.inline_header_count(roundtrip_noko)).to eq(RoundtripHelper.inline_header_count(original_noko))
+          end
+        end
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "collection round-trip" do |flavor_dir:|
+  require "metanorma/collection"
+
+  collections = RoundtripHelper.discover_collections(flavor_dir: flavor_dir)
+
+  collections.each do |fixture|
+    describe fixture[:name] do
+      let(:data) do
+        RoundtripHelper.fixture_data(fixture[:path],
+                                     Metanorma::Collection::Root)
+      end
+      let(:xml) { data[:xml] }
+      let(:doc) { data[:doc] }
+      let(:output_xml) { data[:output_xml] }
+      let(:original_noko) { data[:original_noko] }
+      let(:roundtrip_noko) { data[:roundtrip_noko] }
+
+      it "parses without error" do
+        expect(doc).to be_a(Metanorma::Collection::Root)
+      end
+
+      it "produces valid XML" do
+        expect(RoundtripHelper).not_to be_xml_has_errors(output_xml)
+      end
+
+      it "round-trips root element name" do
+        expect(roundtrip_noko.root.name).to eq("metanorma-collection")
+      end
+
+      it "round-trips collection bibdata type" do
+        expect(RoundtripHelper.bibdata_type(roundtrip_noko)).to eq("collection")
+      end
+
+      it "round-trips collection title" do
+        orig_title = original_noko.at_css("bibdata > title")&.text&.strip
+        rt_title = roundtrip_noko.at_css("bibdata > title")&.text&.strip
+        expect(rt_title).to eq(orig_title)
+      end
+
+      it "round-trips collection docidentifier" do
+        orig_id = original_noko.at_css("bibdata > docidentifier")&.text&.strip
+        rt_id = roundtrip_noko.at_css("bibdata > docidentifier")&.text&.strip
+        expect(rt_id).to eq(orig_id)
+      end
+
+      it "round-trips directive count" do
+        expect(RoundtripHelper.collection_directive_count(roundtrip_noko)).to eq(
+          RoundtripHelper.collection_directive_count(original_noko),
+        )
+      end
+
+      it "round-trips entry count" do
+        expect(RoundtripHelper.collection_entry_count(roundtrip_noko)).to eq(
+          RoundtripHelper.collection_entry_count(original_noko),
+        )
+      end
+
+      it "round-trips doc-container count" do
+        expect(RoundtripHelper.doc_container_count(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_count(original_noko),
+        )
+      end
+
+      it "round-trips doc-container IDs" do
+        expect(RoundtripHelper.doc_container_ids(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_ids(original_noko),
+        )
+      end
+
+      it "round-trips embedded document docidentifiers" do
+        expect(RoundtripHelper.doc_container_docidentifiers(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_docidentifiers(original_noko),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Metanorma::Generic::Document` is now the canonical name for the generic flavor document model. The model moved from `lib/metanorma/generic_document*` in metanorma-document to `lib/metanorma/generic/document*` in metanorma-generic, matching the `Metanorma::<Flavor>::Document::*` ecosystem pattern.

Part of the coordinated multi-PR Phase 4 migration tracked in metanorma-iso `TODO.validate/36-model-ownership-migration.md`:
- **metanorma/metanorma-standoc#1232** — StandardDocument → Standoc::Document
- **metanorma/metanorma-iso#1618** — IsoDocument → Iso::Document
- **metanorma/metanorma-document#45** — marks old autoloads as deprecated
- **This PR** — GenericDocument → Generic::Document
- (follow-up PRs for other flavors)

## Changes

- Copy `lib/metanorma/generic_document*` (2 files) from metanorma-document → `lib/metanorma/generic/document*` (byte-identical source).
- Rename namespace: `Metanorma::GenericDocument` → `Metanorma::Generic::Document`.
- File paths: `lib/metanorma/generic_document*` → `lib/metanorma/generic/document*`.
- Absolute refs: `Metanorma::StandardDocument::*` → `Metanorma::Standoc::Document::*`.
- Forward-declare `Metanorma::Generic` in `document.rb` for direct-require safety.
- Wire `lib/metanorma/generic.rb` to require `metanorma/generic/document`.
- Backwards-compat alias `Metanorma::GenericDocument = Metanorma::Generic::Document` via `deprecate_constant`.
- Cross-PR Gemfile branch pins so CI resolves the chain.
- Add `spec/generic_document_namespace_spec.rb` (8 examples).

## Test verification

Locally green:
- `bundle exec rspec spec/generic_document_namespace_spec.rb` — 8 examples, 0 failures

## Dependencies

Cross-PR Gemfile pins (CI fetches from GitHub):
- `metanorma-standoc` → `feat/move-standard-document` (PR #1232)
- `metanorma-document` → `feat/model-validation-l1-declarations` (PR #45)
- `isodoc`, `relaton-bib`, `pubid` to in-flight branches

All Gemfile pins revert to released gems once their respective PRs merge.

## Test plan

- [ ] CI passes
- [ ] `Metanorma::Generic::Document::Root.name` returns the new canonical name
- [ ] `Metanorma::GenericDocument` alias resolves to the new namespace
- [ ] `ruby -W -e 'require "metanorma/generic"; Metanorma::GenericDocument'` shows deprecation warning
