### PR TITLE
OCP adoption: model tree + core flavor table registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 
+# TEMPORARY cross-PR pins (metanorma-core#18 wave)
+gem "metanorma-core", github: "metanorma/metanorma-core", branch: "feat/flavor-table"
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,13 @@ gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/mo
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 
+# pubid-2 / relaton-bib 2.2 chain (isodoc PR#825)
+gem "isodoc",
+    github: "metanorma/isodoc",
+    branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid",
+    github: "pubid/pubid",
+    branch: "main"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-vali
 gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
+gem "relaton-cli", ">= 2.2.0.pre.alpha.1"
 gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
 gem "pubid",
     github: "pubid/pubid",

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,4 @@ gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
 gem "relaton-cli", ">= 3.0.0.pre.alpha.1"
-gem "pubid", ">= 2.0.0.pre.alpha.9"
+gem "pubid", "2.0.0.pre.alpha.8" # relaton 3.0.0.pre.alpha.1 pairs with pre-rename pubid; .alpha.9 renamed base_identifier->base

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 
-# TEMPORARY cross-PR pins (metanorma-core#18 wave)
+# TEMPORARY cross-PR pins (metanorma-core#18 wave) — identical block in
+# every adoption PR; delete when the branches release.
 gem "metanorma-core", github: "metanorma/metanorma-core", branch: "feat/flavor-table"
 gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
@@ -21,5 +22,3 @@ gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
 gem "pubid",
     github: "pubid/pubid",
     branch: "main"
-
-eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,9 @@ gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/mo
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 
-# pubid-2 / relaton-bib 2.2 chain (isodoc PR#825)
+# relaton v3 monogem + pubid-2 prerelease chain (isodoc PR#825)
 gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
-gem "relaton-cli", ">= 2.2.0.pre.alpha.1"
-gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
-gem "pubid",
-    github: "pubid/pubid",
-    branch: "main"
+gem "relaton-cli", ">= 3.0.0.pre.alpha.1"
+gem "pubid", ">= 2.0.0.pre.alpha.9"

--- a/lib/metanorma-ietf.rb
+++ b/lib/metanorma-ietf.rb
@@ -10,3 +10,4 @@ require_relative "metanorma/ietf/validate"
 require_relative "isodoc/ietf/rfc_convert"
 
 Metanorma::Registry.instance.register(Metanorma::Ietf::Processor)
+require "metanorma/ietf/document"

--- a/lib/metanorma-ietf.rb
+++ b/lib/metanorma-ietf.rb
@@ -10,4 +10,3 @@ require_relative "metanorma/ietf/validate"
 require_relative "isodoc/ietf/rfc_convert"
 
 Metanorma::Registry.instance.register(Metanorma::Ietf::Processor)
-require "metanorma/ietf/document"

--- a/lib/metanorma/ietf.rb
+++ b/lib/metanorma/ietf.rb
@@ -4,5 +4,6 @@ require_relative "ietf/version"
 module Metanorma
   module Ietf
   	RFC2629DTD_URL = "https://raw.githubusercontent.com/metanorma/metanorma-ietf/master/rfc2629.dtd"
+    autoload :Document, "metanorma/ietf/document"
   end
 end

--- a/lib/metanorma/ietf/document.rb
+++ b/lib/metanorma/ietf/document.rb
@@ -19,6 +19,9 @@ module Metanorma
   end
 end
 
+require "metanorma/ietf/registers"
+Metanorma::Ietf::Registers.setup
+
 # OCP adoption: ONE registration in the metanorma-core flavor table
 require "metanorma-core"
 

--- a/lib/metanorma/ietf/document.rb
+++ b/lib/metanorma/ietf/document.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Ietf
+  end
+end
+
+module Metanorma
+  module Ietf::Document
+  end
+end
+
+module Metanorma
+  existing = defined?(Metanorma::IetfDocument) && Metanorma::IetfDocument
+  if !existing.equal?(Metanorma::Ietf::Document)
+    Metanorma.send(:remove_const, :IetfDocument) if existing
+    IetfDocument = Metanorma::Ietf::Document
+  end
+end
+
+# OCP adoption: ONE registration in the metanorma-core flavor table
+require "metanorma-core"
+
+Metanorma::Core::Flavors.register(Metanorma::Core::Flavor.new(
+  name: :ietf,
+  gem: "metanorma-ietf",
+  model_root: Metanorma::Ietf::Document::Root,
+  pubid_module: nil,
+  renderers: { html: Metanorma::Html::StandardRenderer },
+))

--- a/lib/metanorma/ietf/document.rb
+++ b/lib/metanorma/ietf/document.rb
@@ -8,6 +8,9 @@ end
 
 module Metanorma
   module Ietf::Document
+    autoload :Metadata, "metanorma/ietf/document/metadata"
+    autoload :Root, "metanorma/ietf/document/root"
+    autoload :Sections, "metanorma/ietf/document/sections"
   end
 end
 
@@ -30,5 +33,7 @@ Metanorma::Core::Flavors.register(Metanorma::Core::Flavor.new(
   gem: "metanorma-ietf",
   model_root: Metanorma::Ietf::Document::Root,
   pubid_module: nil,
-  renderers: { html: Metanorma::Html::StandardRenderer },
+  renderers: { html: lambda do |_document, **_options|
+    Metanorma::Html::StandardRenderer
+  end },
 ))

--- a/lib/metanorma/ietf/document/metadata.rb
+++ b/lib/metanorma/ietf/document/metadata.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      autoload :IetfBibDataExtensionType,
+               "metanorma/ietf_document/metadata/ietf_bib_data_extension_type"
+      autoload :IetfBibliographicItem,
+               "metanorma/ietf_document/metadata/ietf_bibliographic_item"
+      autoload :IetfEditorialGroup,
+               "metanorma/ietf_document/metadata/ietf_editorial_group"
+      autoload :PiSettings,
+               "metanorma/ietf_document/metadata/pi_settings"
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata.rb
+++ b/lib/metanorma/ietf/document/metadata.rb
@@ -4,13 +4,13 @@ module Metanorma
   module Ietf::Document
     module Metadata
       autoload :IetfBibDataExtensionType,
-               "metanorma/ietf_document/metadata/ietf_bib_data_extension_type"
+               "metanorma/ietf/document/metadata/ietf_bib_data_extension_type"
       autoload :IetfBibliographicItem,
-               "metanorma/ietf_document/metadata/ietf_bibliographic_item"
+               "metanorma/ietf/document/metadata/ietf_bibliographic_item"
       autoload :IetfEditorialGroup,
-               "metanorma/ietf_document/metadata/ietf_editorial_group"
+               "metanorma/ietf/document/metadata/ietf_editorial_group"
       autoload :PiSettings,
-               "metanorma/ietf_document/metadata/pi_settings"
+               "metanorma/ietf/document/metadata/pi_settings"
     end
   end
 end

--- a/lib/metanorma/ietf/document/metadata/ietf_bib_data_extension_type.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_bib_data_extension_type.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class IetfBibDataExtensionType < Lutaml::Model::Serializable
+        attribute :doctype, :string
+        attribute :flavor, :string
+        attribute :ipr, :string
+        attribute :consensus, :string
+        attribute :area, :string, collection: true
+        attribute :submission_type, :string
+        attribute :editorial_group, IetfEditorialGroup
+        attribute :pi, PiSettings
+
+        xml do
+          element "ext"
+          map_element "doctype", to: :doctype
+          map_element "flavor", to: :flavor
+          map_element "ipr", to: :ipr
+          map_element "consensus", to: :consensus
+          map_element "area", to: :area
+          map_element "submissionType", to: :submission_type
+          map_element "editorial-group", to: :editorial_group
+          map_element "editorialgroup", to: :editorial_group
+          map_element "pi", to: :pi
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/ietf_bibliographic_item.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_bibliographic_item.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class IetfBibliographicItem < Metanorma::Document::Components::BibData::BibliographicItem
+        attribute :ext, Metanorma::Ietf::Document::Metadata::IetfBibDataExtensionType
+
+        xml do
+          element "bibdata"
+          map_attribute "type", to: :type_attr
+          map_attribute "schema-version", to: :schema_version
+          map_element "fetched", to: :fetched
+          map_element "title", to: :title
+          map_element "formattedref", to: :formatted_ref
+          map_element "uri", to: :link
+          map_element "docidentifier", to: :docidentifier
+          map_element "docnumber", to: :docnumber
+          map_element "date", to: :date
+          map_element "contributor", to: :contributor
+          map_element "edition", to: :edition
+          map_element "version", to: :version
+          map_element "note", to: :note
+          map_element "language", to: :language
+          map_element "script", to: :script
+          map_element "abstract", to: :abstract
+          map_element "status", to: :status
+          map_element "copyright", to: :copyright
+          map_element "relation", to: :relation
+          map_element "series", to: :series
+          map_element "medium", to: :medium
+          map_element "place", to: :place
+          map_element "price", to: :price
+          map_element "extent", to: :extent
+          map_element "size", to: :size
+          map_element "accessLocation", to: :access_location
+          map_element "license", to: :license
+          map_element "classification", to: :classification
+          map_element "keyword", to: :keyword
+          map_element "validity", to: :validity
+          map_element "ext", to: :ext
+          map_attribute "id", to: :id
+          map_attribute "anchor", to: :anchor
+          map_attribute "semx-id", to: :semx_id
+          map_attribute "schema-version", to: :schema_version
+          map_element "biblio-tag", to: :biblio_tag
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/ietf_editorial_group.rb
+++ b/lib/metanorma/ietf/document/metadata/ietf_editorial_group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      # IETF editorial group containing workgroup names.
+      class IetfEditorialGroup < Lutaml::Model::Serializable
+        attribute :workgroup, :string, collection: true
+
+        xml do
+          element "editorialgroup"
+          map_element "workgroup", to: :workgroup
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/metadata/pi_settings.rb
+++ b/lib/metanorma/ietf/document/metadata/pi_settings.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Metadata
+      class PiSettings < Lutaml::Model::Serializable
+        attribute :toc, :string
+        attribute :tocdepth, :string
+        attribute :symrefs, :string
+        attribute :sortrefs, :string
+        attribute :compact, :string
+        attribute :subcompact, :string
+        attribute :strict, :string
+        attribute :comments, :string
+        attribute :notedraftinprogress, :string
+
+        xml do
+          element "pi"
+          map_element "toc", to: :toc
+          map_element "tocdepth", to: :tocdepth
+          map_element "symrefs", to: :symrefs
+          map_element "sortrefs", to: :sortrefs
+          map_element "compact", to: :compact
+          map_element "subcompact", to: :subcompact
+          map_element "strict", to: :strict
+          map_element "comments", to: :comments
+          map_element "notedraftinprogress", to: :notedraftinprogress
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/root.rb
+++ b/lib/metanorma/ietf/document/root.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::StandardDocument::RootAttributes
+
+      def self.lutaml_default_register
+        :ietf_document
+      end
+
+      attribute :bibdata,
+                Metanorma::Ietf::Document::Metadata::IetfBibliographicItem
+      attribute :preface,
+                Metanorma::StandardDocument::Sections::Preface
+      attribute :sections,
+                Metanorma::Ietf::Document::Sections::IetfSections
+      attribute :annex,
+                Metanorma::Ietf::Document::Sections::IetfAnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::StandardDocument::Namespace
+
+        Metanorma::StandardDocument::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/root.rb
+++ b/lib/metanorma/ietf/document/root.rb
@@ -3,7 +3,7 @@
 module Metanorma
   module Ietf::Document
     class Root < Lutaml::Model::Serializable
-      include Metanorma::StandardDocument::RootAttributes
+      include Metanorma::Standoc::Document::RootAttributes
 
       def self.lutaml_default_register
         :ietf_document
@@ -12,7 +12,7 @@ module Metanorma
       attribute :bibdata,
                 Metanorma::Ietf::Document::Metadata::IetfBibliographicItem
       attribute :preface,
-                Metanorma::StandardDocument::Sections::Preface
+                Metanorma::Standoc::Document::Sections::Preface
       attribute :sections,
                 Metanorma::Ietf::Document::Sections::IetfSections
       attribute :annex,
@@ -21,9 +21,9 @@ module Metanorma
 
       xml do
         element "metanorma"
-        namespace Metanorma::StandardDocument::Namespace
+        namespace Metanorma::Standoc::Document::Namespace
 
-        Metanorma::StandardDocument::RootXmlMapping.apply(self)
+        Metanorma::Standoc::Document::RootXmlMapping.apply(self)
       end
     end
   end

--- a/lib/metanorma/ietf/document/sections.rb
+++ b/lib/metanorma/ietf/document/sections.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      autoload :IetfSections, "#{__dir__}/sections/ietf_sections"
+      autoload :IetfContentSection, "#{__dir__}/sections/ietf_content_section"
+      autoload :IetfClauseSection, "#{__dir__}/sections/ietf_clause_section"
+      autoload :IetfAnnexSection, "#{__dir__}/sections/ietf_annex_section"
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfAnnexSection < Metanorma::StandardDocument::Sections::AnnexSection
+        # IETF-specific attributes
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Sub-clauses within IETF annex use IetfClauseSection
+        attribute :clause, IetfClauseSection, collection: true
+
+        xml do
+          element "annex"
+          ordered
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_attributes(self)
+          map_attribute "numbered",    to: :numbered
+          map_attribute "removeInRFC", to: :remove_in_rfc
+          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_annex_section.rb
@@ -3,7 +3,7 @@
 module Metanorma
   module Ietf::Document
     module Sections
-      class IetfAnnexSection < Metanorma::StandardDocument::Sections::AnnexSection
+      class IetfAnnexSection < Metanorma::Standoc::Document::Sections::AnnexSection
         # IETF-specific attributes
         attribute :numbered, :string
         attribute :remove_in_rfc, :boolean
@@ -15,10 +15,10 @@ module Metanorma
           element "annex"
           ordered
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_attributes(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_attributes(self)
           map_attribute "numbered",    to: :numbered
           map_attribute "removeInRFC", to: :remove_in_rfc
-          Metanorma::StandardDocument::SectionXmlMapping.apply_annex_elements(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_annex_elements(self)
         end
       end
     end

--- a/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfClauseSection < Metanorma::StandardDocument::Sections::ClauseSection
+        # IETF-specific attributes
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Recursive IETF sub-clauses
+        attribute :clause, IetfClauseSection, collection: true
+
+        xml do
+          element "clause"
+          ordered
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_clause_attributes(self)
+          map_attribute "numbered",    to: :numbered
+          map_attribute "removeInRFC", to: :remove_in_rfc
+          Metanorma::StandardDocument::SectionXmlMapping.apply_clause_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_clause_section.rb
@@ -3,7 +3,7 @@
 module Metanorma
   module Ietf::Document
     module Sections
-      class IetfClauseSection < Metanorma::StandardDocument::Sections::ClauseSection
+      class IetfClauseSection < Metanorma::Standoc::Document::Sections::ClauseSection
         # IETF-specific attributes
         attribute :numbered, :string
         attribute :remove_in_rfc, :boolean
@@ -15,10 +15,10 @@ module Metanorma
           element "clause"
           ordered
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_clause_attributes(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_clause_attributes(self)
           map_attribute "numbered",    to: :numbered
           map_attribute "removeInRFC", to: :remove_in_rfc
-          Metanorma::StandardDocument::SectionXmlMapping.apply_clause_elements(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_clause_elements(self)
         end
       end
     end

--- a/lib/metanorma/ietf/document/sections/ietf_content_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_content_section.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      class IetfContentSection < Metanorma::StandardDocument::Sections::ContentSection
+        attribute :numbered, :string
+        attribute :remove_in_rfc, :boolean
+
+        # Recursive IETF sub-clauses
+        attribute :subsection, IetfContentSection, collection: true
+
+        xml do
+          element "clause"
+          ordered
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_content_section_attributes(self)
+          map_attribute "numbered",       to: :numbered
+          map_attribute "removeInRFC",    to: :remove_in_rfc
+          Metanorma::StandardDocument::SectionXmlMapping.apply_content_section_elements(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_content_section.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_content_section.rb
@@ -3,7 +3,7 @@
 module Metanorma
   module Ietf::Document
     module Sections
-      class IetfContentSection < Metanorma::StandardDocument::Sections::ContentSection
+      class IetfContentSection < Metanorma::Standoc::Document::Sections::ContentSection
         attribute :numbered, :string
         attribute :remove_in_rfc, :boolean
 
@@ -14,10 +14,10 @@ module Metanorma
           element "clause"
           ordered
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_content_section_attributes(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_content_section_attributes(self)
           map_attribute "numbered",       to: :numbered
           map_attribute "removeInRFC",    to: :remove_in_rfc
-          Metanorma::StandardDocument::SectionXmlMapping.apply_content_section_elements(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_content_section_elements(self)
         end
       end
     end

--- a/lib/metanorma/ietf/document/sections/ietf_sections.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_sections.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ietf::Document
+    module Sections
+      # IETF sections container.
+      # Corresponds to ietf.rnc:
+      #   sections = element sections {
+      #     ( clause | terms | term-clause | definitions | floating-title )+
+      #   }
+      #
+      # Extends StandardDocument sections with loose bibitem references
+      # and paragraph elements directly inside sections.
+      class IetfSections < Metanorma::StandardDocument::Sections::Sections
+        attribute :bibitem,
+                  Metanorma::BasicDocument::BibData::BibliographicItem,
+                  collection: true
+        attribute :p,
+                  Metanorma::Document::Components::Paragraphs::ParagraphBlock,
+                  collection: true
+
+        xml do
+          element "sections"
+          ordered
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_sections_elements(self)
+          map_element "bibitem",        to: :bibitem
+          map_element "p",              to: :p
+
+          Metanorma::StandardDocument::SectionXmlMapping.apply_sections_attributes(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ietf/document/sections/ietf_sections.rb
+++ b/lib/metanorma/ietf/document/sections/ietf_sections.rb
@@ -11,7 +11,7 @@ module Metanorma
       #
       # Extends StandardDocument sections with loose bibitem references
       # and paragraph elements directly inside sections.
-      class IetfSections < Metanorma::StandardDocument::Sections::Sections
+      class IetfSections < Metanorma::Standoc::Document::Sections::Sections
         attribute :bibitem,
                   Metanorma::BasicDocument::BibData::BibliographicItem,
                   collection: true
@@ -23,11 +23,11 @@ module Metanorma
           element "sections"
           ordered
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_sections_elements(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_sections_elements(self)
           map_element "bibitem",        to: :bibitem
           map_element "p",              to: :p
 
-          Metanorma::StandardDocument::SectionXmlMapping.apply_sections_attributes(self)
+          Metanorma::Standoc::Document::SectionXmlMapping.apply_sections_attributes(self)
         end
       end
     end

--- a/lib/metanorma/ietf/registers.rb
+++ b/lib/metanorma/ietf/registers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Metanorma
+  module Ietf
+    # ietf's lutaml-model register: type substitutions from standoc.
+    # Formerly Metanorma::Registers::Setup.setup_ietf_register in metanorma-document.
+    module Registers
+      module_function
+
+      def setup
+          sd = Metanorma::StandardDocument
+          reg = Lutaml::Model::Register.new(:ietf_document)
+          Lutaml::Model::GlobalRegister.register(reg)
+
+          reg.register_global_type_substitution(
+            from_type: sd::Sections::Sections,
+            to_type: Metanorma::Ietf::Document::Sections::IetfSections,
+          )
+          reg.register_global_type_substitution(
+            from_type: sd::Sections::ContentSection,
+            to_type: Metanorma::Ietf::Document::Sections::IetfContentSection,
+          )
+          reg.register_global_type_substitution(
+            from_type: sd::Sections::ClauseSection,
+            to_type: Metanorma::Ietf::Document::Sections::IetfClauseSection,
+          )
+          reg.register_global_type_substitution(
+            from_type: sd::Sections::AnnexSection,
+            to_type: Metanorma::Ietf::Document::Sections::IetfAnnexSection,
+          )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Model tree extracted from metanorma-document@main and registered with the metanorma-core flavor table (metanorma-core#18). One entry: model_root, renderer, pubid. Part of the full-OCP restructure wave.